### PR TITLE
fix(repos): avoid kernel version mismatch when using container

### DIFF
--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -1,6 +1,11 @@
-- name: Install linux headers for the running kernel
+- name: Get kernel version
+  ansible.builtin.command: uname -r
+  register: kernel_version
+  changed_when: false
+
+- name: Ensure linux headers installed
   ansible.builtin.apt:
-    name: linux-headers-{{ ansible_kernel }}
+    name: linux-headers-{{ kernel_version.stdout }}
     state: present
   become: true
 


### PR DESCRIPTION
## Description

This PR addresses an issue where `ansible_kernel`, an Ansible built-in variable, retrieves the kernel version of the host instead of the container.
When we build inside a Docker container, referencing the host's kernel version leads to mismatches.
To resolve this, the task now explicitly calls `uname -r` inside the container to obtain the correct kernel version.

## How was this PR tested?

Evaluator: [TIER IV Internal Link](https://evaluation.tier4.jp/evaluation/reports/14522239-8822-5d04-929d-cf7c4801c0cd?project_id=prd_jt)

## Notes for reviewers

None.

## Effects on system behavior

None.
