### PR TITLE
ci: fix permission issue for docker-build-and-push-cuda

### DIFF
--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -165,6 +165,11 @@ jobs:
             lib-dir: aarch64
     runs-on: ${{ matrix.runner }}
     steps:
+      # https://github.com/actions/checkout/issues/211
+      - name: Change permission of workspace
+        run: |
+          sudo chown -R $USER:$USER ${{ github.workspace }}
+
       - name: Check out repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description

This fixes [the failure in docker-build-and-push-cuda](https://github.com/autowarefoundation/autoware/actions/runs/16778596926/job/47517508443) workflow by modifying permission of the workspace.

Similar to what is applied for non-cuda job.
https://github.com/autowarefoundation/autoware/blob/main/.github/workflows/docker-build-and-push.yaml#L31-34

## How was this PR tested?
I'm currently testing in https://github.com/autowarefoundation/autoware/actions/runs/16808615712

## Notes for reviewers

None.

## Effects on system behavior

None.
