### PR TITLE
feat(docker): add universe api container image

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -259,6 +259,32 @@ runs:
         flavor: |
           latest=false
 
+    - name: Docker meta for autoware:universe-api-devel
+      id: meta-universe-api-devel
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
+        tags: |
+          type=raw,value=universe-api-devel-${{ inputs.platform }}
+          type=raw,value=universe-api-devel-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-api-devel-,suffix=-${{ inputs.platform }}
+        bake-target: docker-metadata-action-universe-api-devel
+        flavor: |
+          latest=false
+
+    - name: Docker meta for autoware:universe-api
+      id: meta-universe-api
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
+        tags: |
+          type=raw,value=universe-api-${{ inputs.platform }}
+          type=raw,value=universe-api-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-api-,suffix=-${{ inputs.platform }}
+        bake-target: docker-metadata-action-universe-api
+        flavor: |
+          latest=false
+
     - name: Docker meta for autoware:universe-devel
       id: meta-universe-devel
       uses: docker/metadata-action@v5
@@ -312,6 +338,8 @@ runs:
           ${{ steps.meta-universe-vehicle-system.outputs.bake-file }}
           ${{ steps.meta-universe-visualization-devel.outputs.bake-file }}
           ${{ steps.meta-universe-visualization.outputs.bake-file }}
+          ${{ steps.meta-universe-api-devel.outputs.bake-file }}
+          ${{ steps.meta-universe-api.outputs.bake-file }}
           ${{ steps.meta-universe-devel.outputs.bake-file }}
           ${{ steps.meta-universe.outputs.bake-file }}
         provenance: false

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -156,6 +156,23 @@ RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} --dependency-ty
   > /rosdep-universe-vehicle-system-exec-depend-packages.txt \
   && cat /rosdep-universe-vehicle-system-exec-depend-packages.txt
 
+FROM rosdep-depend AS rosdep-universe-api-depend
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+
+COPY src/universe/autoware_universe/launch/tier4_autoware_api_launch /autoware/src/universe/autoware_universe/launch/tier4_autoware_api_launch
+COPY src/universe/autoware_universe/system/autoware_default_adapi /autoware/src/universe/autoware_universe/system/autoware_default_adapi
+COPY src/universe/autoware_universe/system/autoware_default_adapi_helpers/autoware_adapi_adaptors /autoware/src/universe/autoware_universe/system/autoware_default_adapi_helpers/autoware_adapi_adaptors
+COPY src/universe/autoware_universe/system/autoware_diagnostic_graph_utils /autoware/src/universe/autoware_universe/system/autoware_diagnostic_graph_utils
+COPY src/universe/autoware_universe/map/autoware_map_height_fitter /autoware/src/universe/autoware_universe/map/autoware_map_height_fitter
+
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
+  > /rosdep-universe-api-depend-packages.txt \
+  && cat /rosdep-universe-api-depend-packages.txt
+RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} --dependency-types=exec \
+  > /rosdep-universe-api-exec-depend-packages.txt \
+  && cat /rosdep-universe-api-exec-depend-packages.txt
+
 FROM rosdep-depend AS rosdep-universe-depend
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
@@ -458,6 +475,34 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]
 
+FROM universe-common-devel AS universe-api-devel
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+ENV CCACHE_DIR="/root/.ccache"
+
+# Install rosdep dependencies
+COPY --from=rosdep-universe-api-depend /rosdep-universe-api-depend-packages.txt /tmp/rosdep-universe-api-depend-packages.txt
+# hadolint ignore=SC2002
+RUN --mount=type=ssh \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  apt-get update \
+  && cat /tmp/rosdep-universe-api-depend-packages.txt | xargs apt-get install -y --no-install-recommends \
+  && /autoware/cleanup_apt.sh
+
+# hadolint ignore=SC1091
+RUN --mount=type=cache,target=${CCACHE_DIR} \
+  --mount=type=bind,source=src/universe/autoware_universe/launch/tier4_autoware_api_launch,target=/autoware/src/universe/autoware_universe/launch/tier4_autoware_api_launch \
+  --mount=type=bind,source=src/universe/autoware_universe/system/autoware_default_adapi,target=/autoware/src/universe/autoware_universe/system/autoware_default_adapi \
+  --mount=type=bind,source=src/universe/autoware_universe/system/autoware_default_adapi_helpers/autoware_adapi_adaptors,target=/autoware/src/universe/autoware_universe/system/autoware_default_adapi_helpers/autoware_adapi_adaptors \
+  --mount=type=bind,source=src/universe/autoware_universe/system/autoware_diagnostic_graph_utils,target=/autoware/src/universe/autoware_universe/system/autoware_diagnostic_graph_utils \
+  --mount=type=bind,source=src/universe/autoware_universe/map/autoware_map_height_fitter,target=/autoware/src/universe/autoware_universe/map/autoware_map_height_fitter \
+  source /opt/ros/"$ROS_DISTRO"/setup.bash \
+  && source /opt/autoware/setup.bash \
+  && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["/bin/bash"]
+
 FROM universe-common-devel AS universe-devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
@@ -477,6 +522,8 @@ COPY --from=universe-localization-mapping-devel /opt/autoware /opt/autoware
 COPY --from=universe-planning-control-devel /opt/autoware /opt/autoware
 COPY --from=universe-vehicle-system-devel /opt/autoware /opt/autoware
 COPY --from=universe-visualization-devel /opt/autoware /opt/autoware
+COPY --from=universe-api-devel /opt/autoware /opt/autoware
+
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,source=src/sensor_component,target=/autoware/src/sensor_component \
@@ -681,6 +728,32 @@ RUN --mount=type=ssh \
   && /autoware/cleanup_system.sh $LIB_DIR $ROS_DISTRO
 
 COPY --from=universe-visualization-devel /opt/autoware /opt/autoware
+
+# Copy bash aliases
+COPY docker/etc/.bash_aliases /root/.bash_aliases
+RUN echo "source /opt/autoware/setup.bash" > /etc/bash.bashrc
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["/bin/bash"]
+
+# hadolint ignore=DL3006
+FROM $AUTOWARE_BASE_IMAGE AS universe-api
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG ROS_DISTRO
+ARG LIB_DIR
+
+# Set up runtime environment
+COPY --from=rosdep-universe-api-depend /rosdep-universe-api-exec-depend-packages.txt /tmp/rosdep-universe-api-exec-depend-packages.txt
+# hadolint ignore=SC2002
+RUN --mount=type=ssh \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  ./setup-dev-env.sh -y --module all --no-nvidia --no-cuda-drivers --runtime openadkit \
+  && pip uninstall -y ansible ansible-core \
+  && apt-get update \
+  && cat /tmp/rosdep-universe-api-exec-depend-packages.txt | xargs apt-get install -y --no-install-recommends \
+  && /autoware/cleanup_system.sh $LIB_DIR $ROS_DISTRO
+
+COPY --from=universe-api-devel /opt/autoware /opt/autoware
 
 # Copy bash aliases
 COPY docker/etc/.bash_aliases /root/.bash_aliases

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -161,10 +161,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
 COPY src/universe/autoware_universe/launch/tier4_autoware_api_launch /autoware/src/universe/autoware_universe/launch/tier4_autoware_api_launch
-COPY src/universe/autoware_universe/system/autoware_default_adapi /autoware/src/universe/autoware_universe/system/autoware_default_adapi
-COPY src/universe/autoware_universe/system/autoware_default_adapi_helpers/autoware_adapi_adaptors /autoware/src/universe/autoware_universe/system/autoware_default_adapi_helpers/autoware_adapi_adaptors
+COPY src/universe/autoware_universe/system/autoware_default_adapi_universe /autoware/src/universe/autoware_universe/system/autoware_default_adapi_universe
+COPY src/core/autoware_core/api/autoware_adapi_adaptors /autoware/src/core/autoware_core/api/autoware_adapi_adaptors
 COPY src/universe/autoware_universe/system/autoware_diagnostic_graph_utils /autoware/src/universe/autoware_universe/system/autoware_diagnostic_graph_utils
-COPY src/universe/autoware_universe/map/autoware_map_height_fitter /autoware/src/universe/autoware_universe/map/autoware_map_height_fitter
+COPY src/core/autoware_core/map/autoware_map_height_fitter /autoware/src/core/autoware_core/map/autoware_map_height_fitter
 
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-api-depend-packages.txt \
@@ -492,10 +492,10 @@ RUN --mount=type=ssh \
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,source=src/universe/autoware_universe/launch/tier4_autoware_api_launch,target=/autoware/src/universe/autoware_universe/launch/tier4_autoware_api_launch \
-  --mount=type=bind,source=src/universe/autoware_universe/system/autoware_default_adapi,target=/autoware/src/universe/autoware_universe/system/autoware_default_adapi \
-  --mount=type=bind,source=src/universe/autoware_universe/system/autoware_default_adapi_helpers/autoware_adapi_adaptors,target=/autoware/src/universe/autoware_universe/system/autoware_default_adapi_helpers/autoware_adapi_adaptors \
+  --mount=type=bind,source=src/universe/autoware_universe/system/autoware_default_adapi_universe,target=/autoware/src/universe/autoware_universe/system/autoware_default_adapi_universe \
+  --mount=type=bind,source=src/core/autoware_core/api/autoware_adapi_adaptors,target=/autoware/src/core/autoware_core/api/autoware_adapi_adaptors \
   --mount=type=bind,source=src/universe/autoware_universe/system/autoware_diagnostic_graph_utils,target=/autoware/src/universe/autoware_universe/system/autoware_diagnostic_graph_utils \
-  --mount=type=bind,source=src/universe/autoware_universe/map/autoware_map_height_fitter,target=/autoware/src/universe/autoware_universe/map/autoware_map_height_fitter \
+  --mount=type=bind,source=src/core/autoware_core/map/autoware_map_height_fitter,target=/autoware/src/core/autoware_core/map/autoware_map_height_fitter \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
   && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware

--- a/docker/README.md
+++ b/docker/README.md
@@ -190,6 +190,14 @@ This stage installs the dependency packages based on `/rosdep-universe-vehicle-s
 
 This stage is an Autoware Universe Vehicle/System runtime container. It only includes the dependencies given by `/rosdep-universe-vehicle-system-exec-depend-packages.txt` and the binaries built in the `universe-vehicle-system-devel` stage.
 
+### `universe-api-devel`
+
+This stage installs the dependency packages based on `/rosdep-universe-api-depend-packages.txt` and builds the API packages.
+
+### `universe-api`
+
+This stage is a Autoware Universe API runtime container. It only includes the dependencies given by `/rosdep-universe-api-exec-depend-packages.txt` and the binaries built in the `universe-api-devel` stage.
+
 ### `universe-devel`
 
 This stage installs the dependency packages based on `/rosdep-universe-depend-packages.txt` and copies the binaries built in the following stages:
@@ -199,6 +207,7 @@ This stage installs the dependency packages based on `/rosdep-universe-depend-pa
 - `universe-planning-control-devel`
 - `universe-vehicle-system-devel`
 - `universe-visualization-devel`
+- `universe-api-devel`
 
 Then it builds the remaining packages of `autoware.repos`:
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -165,6 +165,8 @@ build_images() {
         --set "universe-vehicle-system.tags=ghcr.io/autowarefoundation/autoware:universe-vehicle-system" \
         --set "universe-visualization-devel.tags=ghcr.io/autowarefoundation/autoware:universe-visualization-devel" \
         --set "universe-visualization.tags=ghcr.io/autowarefoundation/autoware:universe-visualization" \
+        --set "universe-api-devel.tags=ghcr.io/autowarefoundation/autoware:universe-api-devel" \
+        --set "universe-api.tags=ghcr.io/autowarefoundation/autoware:universe-api" \
         --set "universe-devel.tags=ghcr.io/autowarefoundation/autoware:universe-devel" \
         --set "universe.tags=ghcr.io/autowarefoundation/autoware:universe" \
         --set "universe-sensing-perception-devel-cuda.tags=ghcr.io/autowarefoundation/autoware:universe-sensing-perception-devel-cuda" \

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -14,6 +14,8 @@ group "default" {
     "universe-vehicle-system",
     "universe-visualization-devel",
     "universe-visualization",
+    "universe-api-devel",
+    "universe-api",
     "universe-devel",
     "universe"
   ]
@@ -34,6 +36,8 @@ target "docker-metadata-action-universe-vehicle-system-devel" {}
 target "docker-metadata-action-universe-vehicle-system" {}
 target "docker-metadata-action-universe-visualization-devel" {}
 target "docker-metadata-action-universe-visualization" {}
+target "docker-metadata-action-universe-api-devel" {}
+target "docker-metadata-action-universe-api" {}
 target "docker-metadata-action-universe-devel" {}
 target "docker-metadata-action-universe" {}
 
@@ -119,6 +123,18 @@ target "universe-visualization" {
   inherits = ["docker-metadata-action-universe-visualization"]
   dockerfile = "docker/Dockerfile"
   target = "universe-visualization"
+}
+
+target "universe-api-devel" {
+  inherits = ["docker-metadata-action-universe-api-devel"]
+  dockerfile = "docker/Dockerfile"
+  target = "universe-api-devel"
+}
+
+target "universe-api" {
+  inherits = ["docker-metadata-action-universe-api"]
+  dockerfile = "docker/Dockerfile"
+  target = "universe-api"
 }
 
 target "universe-devel" {

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -211,8 +211,7 @@ services:
       - planning-simulation
 
   api:
-    # TODO(youtalk): Create autoware:universe-api image
-    image: ghcr.io/autowarefoundation/autoware:universe
+    image: ghcr.io/autowarefoundation/autoware:universe-api
     container_name: autoware-api
     pid: service:map
     ipc: host


### PR DESCRIPTION
## Description

To complete the modular containers integration we need to also have a distinct api container. This container supports new AD API.

## How was this PR tested?

Built and tested with planning and rosbag simulation with:
[API container](https://github.com/oguzkaganozt/autoware/pkgs/container/autoware/552483675?tag=universe-api-devel-amd64)

## Notes for reviewers

None.

## Effects on system behavior

None.
