### PR TITLE
fix: agnocast role of ansible script

### DIFF
--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -105,7 +105,7 @@
 
 - name: Display info when skipping agnocast-kmod in container
   ansible.builtin.debug:
-    msg: "INFO: Skipping agnocast-kmod installation in container environment"
+    msg: "WARNING: Running in container environment. Skipping agnocast-kmod installation. Please ensure agnocast-kmod is installed on the host system for proper functionality of agnocast."
   when: agnocast_is_container
 
 - name: Install agnocast-kmod if not found in dkms for version v{{ agnocast_version }}

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -1,57 +1,3 @@
-# Detect container environment
-- name: Check if running in a container using systemd-detect-virt
-  ansible.builtin.command: systemd-detect-virt -c
-  register: agnocast_container_detection
-  failed_when: false
-  changed_when: false
-
-- name: Set container environment fact
-  ansible.builtin.set_fact:
-    agnocast_is_container: "{{ agnocast_container_detection.rc == 0 }}"
-
-- name: Display environment detection result
-  ansible.builtin.debug:
-    msg: "Running in container: {{ agnocast_is_container }} (detected: {{ agnocast_container_detection.stdout | default('none') }})"
-
-# Check and install linux headers
-- name: Check if linux-headers package is available
-  ansible.builtin.shell: |
-    set -o pipefail
-    apt-cache search ^linux-headers-{{ ansible_kernel }}$ | grep -q linux-headers-{{ ansible_kernel }}
-  args:
-    executable: /bin/bash
-  register: agnocast_linux_headers_available
-  failed_when: false
-  changed_when: false
-  become: true
-  when: not agnocast_is_container
-
-- name: Display warning if linux-headers is not available
-  ansible.builtin.debug:
-    msg: "WARNING: linux-headers-{{ ansible_kernel }} package not found. The agnocast-kmod installation may fail. Please manually install the kernel headers and re-run this role."
-  when:
-    - not agnocast_is_container
-    - agnocast_linux_headers_available.rc != 0
-
-- name: Install linux headers for the running kernel
-  ansible.builtin.apt:
-    name: linux-headers-{{ ansible_kernel }}
-    state: present
-  register: agnocast_linux_headers_install
-  failed_when: false
-  become: true
-  when:
-    - not agnocast_is_container
-    - agnocast_linux_headers_available.rc == 0
-
-- name: Display warning if linux-headers installation failed
-  ansible.builtin.debug:
-    msg: "WARNING: linux-headers-{{ ansible_kernel }} installation failed. DKMS installation may also fail."
-  when:
-    - not agnocast_is_container
-    - agnocast_linux_headers_available.rc == 0
-    - agnocast_linux_headers_install.failed | default(false)
-
 # TODO(rej55, sykwer): IPv6 support
 - name: Save current IPv6 settings
   ansible.builtin.shell: |
@@ -100,52 +46,95 @@
     state: present
   become: true
 
-- name: Check if agnocast-kmod is installed in dkms with version v{{ agnocast_version }}
-  ansible.builtin.shell: dkms status | grep agnocast | grep {{ agnocast_version }} # noqa: risky-shell-pipe
-  register: agnocast_dkms_status
+# Detect container environment
+- name: Check if running in a container using systemd-detect-virt
+  ansible.builtin.command: systemd-detect-virt -c
+  register: agnocast_container_detection
   failed_when: false
   changed_when: false
-  when: not agnocast_is_container
 
-- name: Purge agnocast-kmod if not found in dkms for version v{{ agnocast_version }}
-  ansible.builtin.apt:
-    name: "{{ agnocast_kmod_package }}"
-    state: absent
-  become: true
-  when:
-    - not agnocast_is_container
-    - agnocast_dkms_status.rc != 0
+- name: Set container environment fact
+  ansible.builtin.set_fact:
+    agnocast_is_container: "{{ agnocast_container_detection.rc == 0 }}"
+
+- name: Display environment detection result
+  ansible.builtin.debug:
+    msg: "Running in container: {{ agnocast_is_container }} (detected: {{ agnocast_container_detection.stdout | default('none') }})"
 
 - name: Display info when skipping agnocast-kmod in container
   ansible.builtin.debug:
     msg: "WARNING: Running in container environment. Skipping agnocast-kmod installation. Please ensure agnocast-kmod is installed on the host system for proper functionality of agnocast."
   when: agnocast_is_container
 
-- name: Install agnocast-kmod if not found in dkms for version v{{ agnocast_version }}
-  ansible.builtin.apt:
-    name: "{{ agnocast_kmod_package }}"
-    state: present
-  register: agnocast_kmod_install
-  failed_when: false
-  become: true
-  when:
-    - not agnocast_is_container
-    - agnocast_dkms_status.rc != 0
+- name: Handle kernel-related tasks (headers + kmod, non-container only)
+  block:
+    - name: Check if linux-headers package is available
+      ansible.builtin.shell: |
+        set -o pipefail
+        apt-cache search ^linux-headers-{{ ansible_kernel }}$ | grep -q linux-headers-{{ ansible_kernel }}
+      args:
+        executable: /bin/bash
+      register: agnocast_linux_headers_available
+      failed_when: false
+      changed_when: false
+      become: true
 
-- name: Display warning if agnocast-kmod installation failed
-  ansible.builtin.debug:
-    msg: "WARNING: agnocast-kmod installation failed. To use agnocast, please manually download the Linux kernel headers and re-run this script."
-  when:
-    - not agnocast_is_container
-    - agnocast_dkms_status.rc != 0
-    - agnocast_kmod_install.failed | default(false)
+    - name: Display warning if linux-headers is not available
+      ansible.builtin.debug:
+        msg: "WARNING: linux-headers-{{ ansible_kernel }} package not found. The agnocast-kmod installation may fail. Please manually install the kernel headers and re-run this role."
+      when: agnocast_linux_headers_available.rc != 0
 
-- name: Ensure agnocast module is loaded at boot via modules-load.d
-  ansible.builtin.copy:
-    dest: /etc/modules-load.d/agnocast.conf
-    content: "agnocast\n"
-    owner: root
-    group: root
-    mode: "0644"
-  become: true
+    - name: Install linux headers for the running kernel
+      ansible.builtin.apt:
+        name: linux-headers-{{ ansible_kernel }}
+        state: present
+      register: agnocast_linux_headers_install
+      failed_when: false
+      become: true
+      when: agnocast_linux_headers_available.rc == 0
+
+    - name: Display warning if linux-headers installation failed
+      ansible.builtin.debug:
+        msg: "WARNING: linux-headers-{{ ansible_kernel }} installation failed. DKMS installation may also fail."
+      when:
+        - agnocast_linux_headers_available.rc == 0
+        - agnocast_linux_headers_install.failed | default(false)
+
+    - name: Check if agnocast-kmod is installed in dkms with version v{{ agnocast_version }}
+      ansible.builtin.shell: dkms status | grep agnocast | grep {{ agnocast_version }} # noqa: risky-shell-pipe
+      register: agnocast_dkms_status
+      failed_when: false
+      changed_when: false
+
+    - name: Purge agnocast-kmod if not found in dkms for version v{{ agnocast_version }}
+      ansible.builtin.apt:
+        name: "{{ agnocast_kmod_package }}"
+        state: absent
+      become: true
+      when: agnocast_dkms_status.rc != 0
+
+    - name: Install agnocast-kmod if not found in dkms for version v{{ agnocast_version }}
+      ansible.builtin.apt:
+        name: "{{ agnocast_kmod_package }}"
+        state: present
+      register: agnocast_kmod_install
+      failed_when: false
+      become: true
+      when: agnocast_dkms_status.rc != 0
+
+    - name: Display warning if agnocast-kmod installation failed
+      ansible.builtin.debug:
+        msg: "WARNING: agnocast-kmod installation failed. To use agnocast, please manually download the Linux kernel headers and re-run this script."
+      when:
+        - agnocast_dkms_status.rc != 0
+        - agnocast_kmod_install.failed | default(false)
+
+    - name: Ensure agnocast module is loaded at boot via modules-load.d
+      ansible.builtin.copy:
+        dest: /etc/modules-load.d/agnocast.conf
+        content: "agnocast\n"
+        owner: root
+        group: root
+        mode: "0644"
+      become: true
   when: not agnocast_is_container

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -67,7 +67,6 @@
   when: agnocast_is_container
 
 - name: Handle kernel-related tasks (headers + kmod, non-container only)
-  when: not agnocast_is_container
   block:
     - name: Check if linux-headers package is available
       ansible.builtin.shell: |
@@ -90,7 +89,7 @@
         name: linux-headers-{{ ansible_kernel }}
         state: present
       register: agnocast_linux_headers_install
-      failed_when: false
+      ignore_errors: true
       become: true
       when: agnocast_linux_headers_available.rc == 0
 
@@ -102,7 +101,8 @@
         - agnocast_linux_headers_install.failed | default(false)
 
     - name: Check if agnocast-kmod is installed in dkms with version v{{ agnocast_version }}
-      ansible.builtin.shell: dkms status | grep agnocast | grep {{ agnocast_version }} # noqa: risky-shell-pipe
+      #ansible.builtin.shell: dkms status | grep agnocast | grep {{ agnocast_version }} # noqa: risky-shell-pipe
+      ansible.builtin.shell: dkms status agnocast/{{ agnocast_version }} | grep -q 'installed'
       register: agnocast_dkms_status
       failed_when: false
       changed_when: false
@@ -119,7 +119,7 @@
         name: "{{ agnocast_kmod_package }}"
         state: present
       register: agnocast_kmod_install
-      failed_when: false
+      ignore_errors: true
       become: true
       when: agnocast_dkms_status.rc != 0
 

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -101,7 +101,6 @@
         - agnocast_linux_headers_install.failed | default(false)
 
     - name: Check if agnocast-kmod is installed in dkms with version v{{ agnocast_version }}
-      #ansible.builtin.shell: dkms status | grep agnocast | grep {{ agnocast_version }} # noqa: risky-shell-pipe
       ansible.builtin.shell: dkms status agnocast/{{ agnocast_version }} | grep -q 'installed'
       register: agnocast_dkms_status
       failed_when: false

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -1,8 +1,39 @@
+# Detect container environment
+- name: Check if running in a container using systemd-detect-virt
+  ansible.builtin.command: systemd-detect-virt -c
+  register: agnocast_container_detection
+  failed_when: false
+  changed_when: false
+
+- name: Set container environment fact
+  ansible.builtin.set_fact:
+    agnocast_is_container: "{{ agnocast_container_detection.rc == 0 }}"
+
+- name: Display environment detection result
+  ansible.builtin.debug:
+    msg: "Running in container: {{ agnocast_is_container }} (detected: {{ agnocast_container_detection.stdout | default('none') }})"
+
+# Check and install linux headers
+- name: Check if linux-headers package is available
+  ansible.builtin.shell: apt-cache search ^linux-headers-{{ ansible_kernel }}$ | grep -q linux-headers-{{ ansible_kernel }}
+  register: agnocast_linux_headers_available
+  failed_when: false
+  changed_when: false
+  become: true
+
+- name: Display warning if linux-headers is not available
+  ansible.builtin.debug:
+    msg: "WARNING: linux-headers-{{ ansible_kernel }} package not found. The agnocast-kmod installation may fail. Please manually install the kernel headers and re-run this role."
+  when: agnocast_linux_headers_available.rc != 0
+
 - name: Install linux headers for the running kernel
   ansible.builtin.apt:
     name: linux-headers-{{ ansible_kernel }}
     state: present
   become: true
+  when:
+    - agnocast_linux_headers_available.rc == 0
+    - not agnocast_is_container
 
 # TODO(rej55, sykwer): IPv6 support
 - name: Save current IPv6 settings
@@ -57,20 +88,30 @@
   register: agnocast_dkms_status
   failed_when: false
   changed_when: false
+  when: not agnocast_is_container
 
 - name: Purge agnocast-kmod if not found in dkms for version v{{ agnocast_version }}
   ansible.builtin.apt:
     name: "{{ agnocast_kmod_package }}"
     state: absent
   become: true
-  when: agnocast_dkms_status.rc != 0
+  when:
+    - not agnocast_is_container
+    - agnocast_dkms_status.rc != 0
+
+- name: Display info when skipping agnocast-kmod in container
+  ansible.builtin.debug:
+    msg: "INFO: Skipping agnocast-kmod installation in container environment"
+  when: agnocast_is_container
 
 - name: Install agnocast-kmod if not found in dkms for version v{{ agnocast_version }}
   ansible.builtin.apt:
     name: "{{ agnocast_kmod_package }}"
     state: present
   become: true
-  when: agnocast_dkms_status.rc != 0
+  when:
+    - not agnocast_is_container
+    - agnocast_dkms_status.rc != 0
 
 - name: Ensure agnocast module is loaded at boot via modules-load.d
   ansible.builtin.copy:
@@ -80,3 +121,4 @@
     group: root
     mode: "0644"
   become: true
+  when: not agnocast_is_container

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -15,7 +15,11 @@
 
 # Check and install linux headers
 - name: Check if linux-headers package is available
-  ansible.builtin.shell: apt-cache search ^linux-headers-{{ ansible_kernel }}$ | grep -q linux-headers-{{ ansible_kernel }}
+  ansible.builtin.shell: |
+    set -o pipefail
+    apt-cache search ^linux-headers-{{ ansible_kernel }}$ | grep -q linux-headers-{{ ansible_kernel }}
+  args:
+    executable: /bin/bash
   register: agnocast_linux_headers_available
   failed_when: false
   changed_when: false

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -67,6 +67,7 @@
   when: agnocast_is_container
 
 - name: Handle kernel-related tasks (headers + kmod, non-container only)
+  when: not agnocast_is_container
   block:
     - name: Check if linux-headers package is available
       ansible.builtin.shell: |
@@ -137,4 +138,3 @@
         group: root
         mode: "0644"
       become: true
-  when: not agnocast_is_container

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -100,7 +100,7 @@
         - agnocast_linux_headers_available.rc == 0
         - agnocast_linux_headers_install.failed | default(false)
 
-    - name: Check if agnocast-kmod is installed in dkms with version v{{ agnocast_version }}
+    - name: Check if agnocast-kmod is installed in dkms with version v{{ agnocast_version }} # noqa: risky-shell-pipe
       ansible.builtin.shell: dkms status agnocast/{{ agnocast_version }} | grep -q 'installed'
       register: agnocast_dkms_status
       failed_when: false

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -24,20 +24,33 @@
   failed_when: false
   changed_when: false
   become: true
+  when: not agnocast_is_container
 
 - name: Display warning if linux-headers is not available
   ansible.builtin.debug:
     msg: "WARNING: linux-headers-{{ ansible_kernel }} package not found. The agnocast-kmod installation may fail. Please manually install the kernel headers and re-run this role."
-  when: agnocast_linux_headers_available.rc != 0
+  when:
+    - not agnocast_is_container
+    - agnocast_linux_headers_available.rc != 0
 
 - name: Install linux headers for the running kernel
   ansible.builtin.apt:
     name: linux-headers-{{ ansible_kernel }}
     state: present
+  register: agnocast_linux_headers_install
+  failed_when: false
   become: true
   when:
-    - agnocast_linux_headers_available.rc == 0
     - not agnocast_is_container
+    - agnocast_linux_headers_available.rc == 0
+
+- name: Display warning if linux-headers installation failed
+  ansible.builtin.debug:
+    msg: "WARNING: linux-headers-{{ ansible_kernel }} installation failed. DKMS installation may also fail."
+  when:
+    - not agnocast_is_container
+    - agnocast_linux_headers_available.rc == 0
+    - agnocast_linux_headers_install.failed | default(false)
 
 # TODO(rej55, sykwer): IPv6 support
 - name: Save current IPv6 settings
@@ -112,10 +125,20 @@
   ansible.builtin.apt:
     name: "{{ agnocast_kmod_package }}"
     state: present
+  register: agnocast_kmod_install
+  failed_when: false
   become: true
   when:
     - not agnocast_is_container
     - agnocast_dkms_status.rc != 0
+
+- name: Display warning if agnocast-kmod installation failed
+  ansible.builtin.debug:
+    msg: "WARNING: agnocast-kmod installation failed. To use agnocast, please manually download the Linux kernel headers and re-run this script."
+  when:
+    - not agnocast_is_container
+    - agnocast_dkms_status.rc != 0
+    - agnocast_kmod_install.failed | default(false)
 
 - name: Ensure agnocast module is loaded at boot via modules-load.d
   ansible.builtin.copy:


### PR DESCRIPTION
## Description
Below are the changes made in this PR.
  1. Container Environment Detection
  - Auto-detect containers using systemd-detect-virt -c and skip kernel tasks (linux-headers, agnocast-kmod, modules-load.d)
  - Only agnocast-heaphook is installed in containers

  2. Graceful Failure Handling
  - Installation failures show warnings instead of stopping playbook
  - Use ignore_errors: true for apt tasks, failed_when: false for shell tasks

  3. Improved DKMS Status Check
  - Changed from dkms status | grep agnocast to dkms status agnocast/{{ version }} | grep -q 'installed'
  - Detects and reinstalls broken/incomplete DKMS installations

  4. Code Organization
  - Used block syntax to group kernel-related tasks
  - Moved container detection closer to usage point




## How was this PR tested?
```
TASK [autoware.dev_env.agnocast : Install agnocast-heaphook-v2.1.2] *************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
changed: [localhost]

TASK [autoware.dev_env.agnocast : Check if running in a container using systemd-detect-virt] ************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [autoware.dev_env.agnocast : Set container environment fact] ***************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [autoware.dev_env.agnocast : Display environment detection result] *********************************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "Running in container: True (detected: docker)"
}

TASK [autoware.dev_env.agnocast : Display info when skipping agnocast-kmod in container] ****************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "WARNING: Running in container environment. Skipping agnocast-kmod installation. Please ensure agnocast-kmod is installed on the host system for proper functionality of agnocast."
}

TASK [autoware.dev_env.agnocast : Check if linux-headers package is available] **************************************************************************************************************************************************************************************************************************************************************************************************************************************************
skipping: [localhost]

TASK [autoware.dev_env.agnocast : Display warning if linux-headers is not available] ********************************************************************************************************************************************************************************************************************************************************************************************************************************************
skipping: [localhost]

TASK [autoware.dev_env.agnocast : Install linux headers for the running kernel] *************************************************************************************************************************************************************************************************************************************************************************************************************************************************
skipping: [localhost]

TASK [autoware.dev_env.agnocast : Display warning if linux-headers installation failed] *****************************************************************************************************************************************************************************************************************************************************************************************************************************************
skipping: [localhost]

TASK [autoware.dev_env.agnocast : Check if agnocast-kmod is installed in dkms with version v2.1.2] ******************************************************************************************************************************************************************************************************************************************************************************************************************************
skipping: [localhost]

TASK [autoware.dev_env.agnocast : Purge agnocast-kmod if not found in dkms for version v2.1.2] **********************************************************************************************************************************************************************************************************************************************************************************************************************************
skipping: [localhost]

TASK [autoware.dev_env.agnocast : Install agnocast-kmod if not found in dkms for version v2.1.2] ********************************************************************************************************************************************************************************************************************************************************************************************************************************
skipping: [localhost]

TASK [autoware.dev_env.agnocast : Display warning if agnocast-kmod installation failed] *****************************************************************************************************************************************************************************************************************************************************************************************************************************************
skipping: [localhost]

TASK [autoware.dev_env.agnocast : Ensure agnocast module is loaded at boot via modules-load.d] **********************************************************************************************************************************************************************************************************************************************************************************************************************************
skipping: [localhost]

```


## Notes for reviewers

  Error Handling: ignore_errors: true vs failed_when: false

  Why ignore_errors: true for apt installation tasks:

  - failed_when: false → .failed attribute is NOT set on errors → Warning tasks won't trigger
  - ignore_errors: true → .failed attribute IS set on errors → Warning tasks properly trigger

  Note: Shell tasks use failed_when: false because they rely on .rc (return code) instead of .failed.


## Effects on system behavior

None.
