### PR TITLE
fix(build_tools): fix CCACHE_DIR env settings

### DIFF
--- a/ansible/roles/build_tools/tasks/main.yaml
+++ b/ansible/roles/build_tools/tasks/main.yaml
@@ -6,16 +6,21 @@
     update_cache: true
 
 - name: Add CCACHE_DIR to .bashrc
-  become: true
   ansible.builtin.lineinfile:
-    dest: "{{ item }}"
+    dest: ~/.bashrc
     line: export CCACHE_DIR="$HOME/.ccache"
     state: present
     create: true
     mode: 0644
-  loop:
-    - ~/.bashrc
-    - /etc/skel/.bashrc
+
+- name: Add CCACHE_DIR to .bashrc for /etc/skel/.bashrc
+  become: true
+  ansible.builtin.lineinfile:
+    dest: /etc/skel/.bashrc
+    line: export CCACHE_DIR="$HOME/.ccache"
+    state: present
+    create: true
+    mode: 0644
 
 - name: Export CC to ccache
   ansible.builtin.lineinfile:

--- a/ansible/roles/build_tools/tasks/main.yaml
+++ b/ansible/roles/build_tools/tasks/main.yaml
@@ -6,21 +6,16 @@
     update_cache: true
 
 - name: Add CCACHE_DIR to .bashrc
-  ansible.builtin.lineinfile:
-    dest: ~/.bashrc
-    line: export CCACHE_DIR="/var/tmp/ccache"
-    state: present
-    create: true
-    mode: 0644
-
-- name: Add CCACHE_DIR to .bashrc of local user
   become: true
   ansible.builtin.lineinfile:
-    dest: /etc/skel/.bashrc
+    dest: "{{ item }}"
     line: export CCACHE_DIR="$HOME/.ccache"
     state: present
     create: true
     mode: 0644
+  loop:
+    - ~/.bashrc
+    - /etc/skel/.bashrc
 
 - name: Export CC to ccache
   ansible.builtin.lineinfile:
@@ -37,12 +32,6 @@
     state: present
     create: true
     mode: 0644
-
-- name: Create ccache directory
-  ansible.builtin.file:
-    path: /var/tmp/ccache
-    state: directory
-    mode: 0755
 
 - name: Source .bashrc
   ansible.builtin.shell: source ~/.bashrc

--- a/ansible/roles/build_tools/tasks/main.yaml
+++ b/ansible/roles/build_tools/tasks/main.yaml
@@ -13,7 +13,7 @@
     create: true
     mode: 0644
 
-- name: Add CCACHE_DIR to .bashrc for /etc/skel/.bashrc
+- name: Add CCACHE_DIR to .bashrc of local user
   become: true
   ansible.builtin.lineinfile:
     dest: /etc/skel/.bashrc


### PR DESCRIPTION
## Description

When using pre builded base image, duplicate CCACHE_DIR lines are written in image created by Autoware Evaluator.
Here is a sample.
```
# /home/autoware.bashrc
export CCACHE_DIR="$HOME/.ccache" # copy from /etc/skel/.bashrc in base image
export CCACHE_DIR="/var/tmp/ccache" # Written in Autoware Evaluator
```

I fix it to replace `export CCACHE_DIR="/var/tmp/ccache"` to `export CCACHE_DIR="$HOME/.ccache"`.
Moreover, I delete task of creating ccache directory.

## How was this PR tested?

In my PC, I confirmed to be added export CCACHE_DIR="$HOME/.ccache" to `~/.bashrc`


## Notes for reviewers

None.

## Effects on system behavior

None.
