### PR TITLE
feat: install open driver instead for usage in new architecture RTX50XX

### DIFF
--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -62,7 +62,7 @@
   become: true
   ansible.builtin.apt:
     name:
-      - cuda-drivers
+      - nvidia-open
     update_cache: true
   when: cuda_install_drivers | bool
 


### PR DESCRIPTION
## Description

Install the open driver instead, for the NVIDIA card with the new Blackwell Architecture.

### Background Information

1. **Directly installing proprietary for new GPU cards will report error like this:**

<img width="1550" height="703" alt="image" src="https://github.com/user-attachments/assets/6faa467c-e63a-47a1-819c-78563bbeda6c" />

2. There are similar reports on the nvidia forum.

https://forums.developer.nvidia.com/t/unable-to-use-proprietary-570-driver/322337/6

3. Check the official webpage for how to install open kernel modules:

https://docs.nvidia.com/datacenter/tesla/driver-installation-guide/index.html#ubuntu-installation

<img width="1191" height="508" alt="image" src="https://github.com/user-attachments/assets/9162ca9c-27b9-44de-bf83-f43f582cde3d" />

Based on the context, it means that installing with `apt install nvidia-open` is a simple replacement of `apt install cuda-drivers`

## How was this PR tested?

I tested locally with a brand new Ubuntu 22.04 container

## Notes for reviewers

None.

## Effects on system behavior

None.
