### PR TITLE
feat: update Autoware base image for Jazzy

### DIFF
--- a/.github/actions/docker-build-and-push-base/action.yaml
+++ b/.github/actions/docker-build-and-push-base/action.yaml
@@ -12,6 +12,14 @@ inputs:
     default: 2
     description: Maximum parallelism for buildkitd.
     required: false
+  set-latest:
+    description: Whether to set the latest flavor for images.
+    required: false
+    default: true
+  suffix:
+    description: Suffix for image tags.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -35,10 +43,10 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
         tags: |
-          type=raw,value=${{ steps.date.outputs.date }}
+          type=raw,value=${{ steps.date.outputs.date }}${{ inputs.suffix }}
         bake-target: docker-metadata-action-base
         flavor: |
-          latest=true
+          latest=${{ inputs.set-latest }}
 
     - name: Docker meta for autoware-base:cuda-latest
       id: meta-base-cuda
@@ -46,8 +54,8 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
         tags: |
-          type=raw,value=cuda-latest
-          type=raw,value=cuda-${{ steps.date.outputs.date }}
+          type=raw,value=cuda-latest${{ inputs.suffix }}
+          type=raw,value=cuda-${{ steps.date.outputs.date }}${{ inputs.suffix }}
         bake-target: docker-metadata-action-base-cuda
         flavor: |
           latest=false

--- a/.github/workflows/autoware-base.yaml
+++ b/.github/workflows/autoware-base.yaml
@@ -67,28 +67,3 @@ jobs:
             *.args.BASE_IMAGE=${{ steps.load-env.outputs.base_image }}
           suffix: ${{ matrix.suffix }}
           set-latest: ${{ matrix.set-latest }}
-  # autoware-base-jazzy:
-  #   needs: load-env
-  #   runs-on: ubuntu-24.04
-  #   steps:
-  #     - name: Check out this repository
-  #       uses: actions/checkout@v4
-
-  #     - name: Free disk space
-  #       uses: ./.github/actions/free-disk-space
-
-  #     - name: Set up QEMU
-  #       uses: docker/setup-qemu-action@v3
-  #       with: # cSpell:ignore tonistiigi, binfmt
-  #         image: tonistiigi/binfmt:qemu-v7.0.0
-
-  #     - name: Build Autoware's Jazzy base images
-  #       uses: ./.github/actions/docker-build-and-push-base
-  #       with:
-  #         target-image: autoware-base
-  #         build-args: |
-  #           *.platform=linux/amd64
-  #           *.args.ROS_DISTRO=jazzy
-  #           *.args.BASE_IMAGE=ros:jazzy-ros-base-noble
-  #         suffix: -jazzy
-  #         set-latest: false

--- a/.github/workflows/autoware-base.yaml
+++ b/.github/workflows/autoware-base.yaml
@@ -21,12 +21,22 @@ on:
   workflow_dispatch:
 
 jobs:
-  load-env:
-    uses: ./.github/workflows/load-env.yaml
-
   autoware-base:
-    needs: load-env
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        platform: [humble, jazzy]
+        include:
+          - platform: humble
+            runner: ubuntu-22.04
+            env-file: amd64.env
+            suffix: "" # no suffix for humble since it is default
+            set-latest: true
+          - platform: jazzy
+            runner: ubuntu-24.04
+            env-file: amd64_jazzy.env
+            suffix: "-jazzy"
+            set-latest: false
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out this repository
         uses: actions/checkout@v4
@@ -36,8 +46,16 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-        with:
+        with: # cSpell:ignore tonistiigi, binfmt
           image: tonistiigi/binfmt:qemu-v7.0.0
+
+      - name: Load env file
+        id: load-env
+        uses: falti/dotenv-action@v1
+        with:
+          path: ${{ matrix.env-file }}
+          export-variables: true
+          log-variables: true
 
       - name: Build Autoware's base images
         uses: ./.github/actions/docker-build-and-push-base
@@ -45,5 +63,32 @@ jobs:
           target-image: autoware-base
           build-args: |
             *.platform=linux/amd64,linux/arm64
-            *.args.ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
-            *.args.BASE_IMAGE=${{ needs.load-env.outputs.base_image }}
+            *.args.ROS_DISTRO=${{ steps.load-env.outputs.rosdistro }}
+            *.args.BASE_IMAGE=${{ steps.load-env.outputs.base_image }}
+          suffix: ${{ matrix.suffix }}
+          set-latest: ${{ matrix.set-latest }}
+  # autoware-base-jazzy:
+  #   needs: load-env
+  #   runs-on: ubuntu-24.04
+  #   steps:
+  #     - name: Check out this repository
+  #       uses: actions/checkout@v4
+
+  #     - name: Free disk space
+  #       uses: ./.github/actions/free-disk-space
+
+  #     - name: Set up QEMU
+  #       uses: docker/setup-qemu-action@v3
+  #       with: # cSpell:ignore tonistiigi, binfmt
+  #         image: tonistiigi/binfmt:qemu-v7.0.0
+
+  #     - name: Build Autoware's Jazzy base images
+  #       uses: ./.github/actions/docker-build-and-push-base
+  #       with:
+  #         target-image: autoware-base
+  #         build-args: |
+  #           *.platform=linux/amd64
+  #           *.args.ROS_DISTRO=jazzy
+  #           *.args.BASE_IMAGE=ros:jazzy-ros-base-noble
+  #         suffix: -jazzy
+  #         set-latest: false

--- a/.github/workflows/autoware-base.yaml
+++ b/.github/workflows/autoware-base.yaml
@@ -34,7 +34,7 @@ jobs:
           - platform: jazzy
             runner: ubuntu-24.04
             env-file: amd64_jazzy.env
-            suffix: "-jazzy"
+            suffix: -jazzy
             set-latest: false
     runs-on: ${{ matrix.runner }}
     steps:

--- a/amd64_jazzy.env
+++ b/amd64_jazzy.env
@@ -1,0 +1,15 @@
+# ROS distribution (jazzy)
+rosdistro=jazzy
+rmw_implementation=rmw_cyclonedds_cpp
+
+# Jazzy-specific overrides (will be set by build.sh)
+base_image=ros:jazzy-ros-base-noble
+autoware_base_image=ghcr.io/autowarefoundation/autoware-base:jazzy-latest
+autoware_base_cuda_image=ghcr.io/autowarefoundation/autoware-base:jazzy-cuda-latest
+
+cuda_version=12.4
+cudnn_version=8.9.7.29-1+cuda12.2
+tensorrt_version=10.8.0.43-1+cuda12.8
+pre_commit_clang_format_version=17.0.5
+cumm_version=0.5.3
+spconv_version=2.3.8

--- a/ansible/playbooks/openadkit.yaml
+++ b/ansible/playbooks/openadkit.yaml
@@ -4,8 +4,8 @@
   pre_tasks:
     - name: Verify OS
       ansible.builtin.fail:
-        msg: Only Ubuntu 22.04 is supported for this branch. Please refer to https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/.
-      when: ansible_distribution != 'Ubuntu' or ansible_distribution_version != '22.04'
+        msg: Only Ubuntu 22.04 and 24.04 are supported for this branch. Please refer to https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/.
+      when: ansible_distribution != 'Ubuntu' or (ansible_distribution_version != '22.04' and ansible_distribution_version != '24.04')
 
     - name: Print args
       ansible.builtin.debug:
@@ -26,9 +26,9 @@
     - role: autoware.dev_env.gdown
       when: module == 'base'
     - role: autoware.dev_env.kisak_mesa
-      when: module == 'base'
+      when: module == 'base' and rosdistro != 'jazzy'
     - role: autoware.dev_env.pacmod
-      when: module == 'base'
+      when: module == 'base' and rosdistro != 'jazzy'
     - role: autoware.dev_env.build_tools
       when: module == 'all' and install_devel=='y'
 

--- a/ansible/playbooks/rosdep.yaml
+++ b/ansible/playbooks/rosdep.yaml
@@ -4,7 +4,8 @@
   pre_tasks:
     - name: Verify OS
       ansible.builtin.fail:
-        msg: Only Ubuntu 22.04 is supported for this branch. Please refer to https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/.
-      when: ansible_distribution != 'Ubuntu' or ansible_distribution_version != '22.04'
+        msg: Only Ubuntu 22.04 and 24.04 are supported for this branch. Please refer to https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/.
+      when: ansible_distribution != 'Ubuntu' or (ansible_distribution_version != '22.04' and ansible_distribution_version != '24.04')
   roles:
     - role: autoware.dev_env.pacmod
+      when: rosdistro != 'jazzy'

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -20,8 +20,8 @@
   pre_tasks:
     - name: Verify OS
       ansible.builtin.fail:
-        msg: Only Ubuntu 22.04 is supported for this branch. Please refer to https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/.
-      when: ansible_distribution_version != '22.04'
+        msg: Only Ubuntu 22.04 and 24.04 are supported for this branch. Please refer to https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/.
+      when: ansible_distribution != 'Ubuntu' or (ansible_distribution_version != '22.04' and ansible_distribution_version != '24.04')
 
     - name: Print args
       ansible.builtin.debug:
@@ -49,13 +49,14 @@
     - role: autoware.dev_env.gdown
     - role: autoware.dev_env.build_tools
     - role: autoware.dev_env.agnocast
+      when: rosdistro == 'humble'
 
     # Autoware module dependencies
     - role: autoware.dev_env.geographiclib
     - role: autoware.dev_env.cuda
       when: prompt_install_nvidia == 'y'
     - role: autoware.dev_env.pacmod
-      when: rosdistro != 'rolling'
+      when: rosdistro == 'humble'
     - role: autoware.dev_env.tensorrt
       when: prompt_install_nvidia == 'y'
     - role: autoware.dev_env.spconv

--- a/ansible/roles/dev_tools/tasks/main.yaml
+++ b/ansible/roles/dev_tools/tasks/main.yaml
@@ -18,17 +18,22 @@
   when: "'filter.lfs.required' not in dev_tools__git_lfs__git_global_config.config_values"
   changed_when: true
 
-- name: Install pre-commit
-  ansible.builtin.pip:
-    name: pre-commit
+- name: Install pipx
+  become: true
+  ansible.builtin.apt:
+    name: pipx
     state: latest
-    executable: pip3
+    update_cache: true
+
+- name: Install pre-commit
+  community.general.pipx:
+    name: pre-commit
+    executable: /usr/bin/pipx
 
 - name: Install clang-format
-  ansible.builtin.pip:
+  community.general.pipx:
     name: clang-format
-    version: "{{ pre_commit_clang_format_version }}"
-    executable: pip3
+    executable: /usr/bin/pipx      
 
 - name: Install Go
   become: true

--- a/ansible/roles/dev_tools/tasks/main.yaml
+++ b/ansible/roles/dev_tools/tasks/main.yaml
@@ -33,7 +33,7 @@
 - name: Install clang-format
   community.general.pipx:
     name: clang-format
-    executable: /usr/bin/pipx      
+    executable: /usr/bin/pipx
 
 - name: Install Go
   become: true

--- a/ansible/roles/gdown/tasks/main.yaml
+++ b/ansible/roles/gdown/tasks/main.yaml
@@ -1,6 +1,17 @@
+# noqa: risky-shell-pipe, no-changed-when
+
 - name: Install gdown to download files from CMakeLists.txt
+  ansible.builtin.shell: |
+    set -o pipefail
+    pip3 list | grep -q gdown || pip3 install --break-system-packages gdown
+  args:
+    executable: /bin/bash
+  when: rosdistro == 'jazzy'
+
+- name: Install gdown to download files from CMakeLists.txt (non-jazzy)
   ansible.builtin.pip:
     name:
       - gdown
     state: latest
     executable: pip3
+  when: rosdistro != 'jazzy'

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
 # Copy files
-COPY setup-dev-env.sh ansible-galaxy-requirements.yaml amd64.env arm64.env /autoware/
+COPY setup-dev-env.sh ansible-galaxy-requirements.yaml amd64.env amd64_jazzy.env arm64.env /autoware/
 COPY ansible/ /autoware/ansible/
 COPY docker/scripts/cleanup_apt.sh /autoware/cleanup_apt.sh
 RUN chmod +x /autoware/cleanup_apt.sh
@@ -28,8 +28,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # Set up base environment
 RUN --mount=type=ssh \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  ./setup-dev-env.sh -y --module base --no-nvidia --no-cuda-drivers --runtime openadkit \
-  && pip uninstall -y ansible ansible-core \
+  ./setup-dev-env.sh -y --module base --no-nvidia --no-cuda-drivers --runtime openadkit --ros-distro $ROS_DISTRO \
+  && pipx uninstall ansible \
   && /autoware/cleanup_apt.sh \
   && echo "source /opt/ros/${ROS_DISTRO}/setup.bash" > /etc/bash.bashrc
 
@@ -44,6 +44,6 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Set up CUDA runtime environment
 # hadolint ignore=SC2002
 RUN --mount=type=ssh \
-  ./setup-dev-env.sh -y --module base --no-cuda-drivers --runtime openadkit \
-  && pip uninstall -y ansible ansible-core \
+  ./setup-dev-env.sh -y --module base --no-cuda-drivers --runtime openadkit --ros-distro $ROS_DISTRO \
+  && pipx uninstall ansible \
   && /autoware/cleanup_apt.sh true

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -42,7 +42,7 @@ FROM base AS base-cuda
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Set up CUDA runtime environment
-# hadolint ignore=SC2002
+# hadolint ignore=SC2002,SC2086
 RUN --mount=type=ssh \
   ./setup-dev-env.sh -y --module base --no-cuda-drivers --runtime openadkit --ros-distro $ROS_DISTRO \
   && pipx uninstall ansible \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -204,7 +204,6 @@ remove_dangling_images() {
 parse_arguments "$@"
 set_ros_distro
 set_cuda_options
-set_image_tags
 set_build_options
 set_platform
 set_arch_lib_dir

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -12,6 +12,7 @@ print_help() {
     echo "  --platform      Specify the platform (default: current platform)"
     echo "  --devel-only    Build devel image only"
     echo "  --target        Specify the target image (default: universe or universe-devel if --devel-only is set)"
+    echo "  --ros-distro    Specify ROS distribution (humble or jazzy, default: humble)"
     echo ""
     echo "Note: The --platform option should be one of 'linux/amd64' or 'linux/arm64'."
 }
@@ -41,6 +42,10 @@ parse_arguments() {
             option_target="$2"
             shift
             ;;
+        --ros-distro)
+            option_ros_distro="$2"
+            shift
+            ;;
         *)
             echo "Unknown option: $1"
             print_help
@@ -51,6 +56,15 @@ parse_arguments() {
     done
 }
 
+# Set ROS distribution
+set_ros_distro() {
+    if [ -n "$option_ros_distro" ]; then
+        ros_distro="$option_ros_distro"
+    else
+        ros_distro="humble"
+    fi
+}
+
 # Set CUDA options
 set_cuda_options() {
     if [ "$option_no_cuda" = "true" ]; then
@@ -58,6 +72,19 @@ set_cuda_options() {
         image_name_suffix=""
     else
         image_name_suffix="-cuda"
+    fi
+}
+
+# Set image tags based on ROS distro
+set_image_tags() {
+    if [ "$ros_distro" = "jazzy" ]; then
+        base_tag="ghcr.io/autowarefoundation/autoware-base:jazzy-latest"
+        base_cuda_tag="ghcr.io/autowarefoundation/autoware-base:jazzy-cuda-latest"
+        main_tag_suffix="-jazzy"
+    else
+        base_tag="ghcr.io/autowarefoundation/autoware-base:latest"
+        base_cuda_tag="ghcr.io/autowarefoundation/autoware-base:cuda-latest"
+        main_tag_suffix=""
     fi
 }
 
@@ -101,9 +128,17 @@ set_arch_lib_dir() {
 
 # Load env
 load_env() {
+    export ROS_DISTRO="$ros_distro"
     source "$WORKSPACE_ROOT/amd64.env"
     if [ "$platform" = "linux/arm64" ]; then
         source "$WORKSPACE_ROOT/arm64.env"
+    fi
+
+    # Override base image variables for jazzy
+    if [ "$ros_distro" = "jazzy" ]; then
+        base_image="$base_image_jazzy"
+        autoware_base_image="$autoware_base_image_jazzy"
+        autoware_base_cuda_image="$autoware_base_cuda_image_jazzy"
     fi
 }
 
@@ -136,44 +171,85 @@ build_images() {
     echo "Target: $target"
 
     set -x
-    docker buildx bake --allow=ssh --load --progress=plain -f "$SCRIPT_DIR/docker-bake-base.hcl" \
-        --set "*.context=$WORKSPACE_ROOT" \
-        --set "*.ssh=default" \
-        --set "*.platform=$platform" \
-        --set "*.args.ROS_DISTRO=$rosdistro" \
-        --set "*.args.BASE_IMAGE=$base_image" \
-        --set "*.args.SETUP_ARGS=$setup_args" \
-        --set "*.args.LIB_DIR=$lib_dir" \
-        --set "base.tags=ghcr.io/autowarefoundation/autoware-base:latest" \
-        --set "base-cuda.tags=ghcr.io/autowarefoundation/autoware-base:cuda-latest"
-    docker buildx bake --allow=ssh --load --progress=plain -f "$SCRIPT_DIR/docker-bake.hcl" -f "$SCRIPT_DIR/docker-bake-cuda.hcl" \
-        --set "*.context=$WORKSPACE_ROOT" \
-        --set "*.ssh=default" \
-        --set "*.platform=$platform" \
-        --set "*.args.ROS_DISTRO=$rosdistro" \
-        --set "*.args.AUTOWARE_BASE_IMAGE=$autoware_base_image" \
-        --set "*.args.AUTOWARE_BASE_CUDA_IMAGE=$autoware_base_cuda_image" \
-        --set "*.args.SETUP_ARGS=$setup_args" \
-        --set "*.args.LIB_DIR=$lib_dir" \
-        --set "universe-sensing-perception-devel.tags=ghcr.io/autowarefoundation/autoware:universe-sensing-perception-devel" \
-        --set "universe-sensing-perception.tags=ghcr.io/autowarefoundation/autoware:universe-sensing-perception" \
-        --set "universe-localization-mapping-devel.tags=ghcr.io/autowarefoundation/autoware:universe-localization-mapping-devel" \
-        --set "universe-localization-mapping.tags=ghcr.io/autowarefoundation/autoware:universe-localization-mapping" \
-        --set "universe-planning-control-devel.tags=ghcr.io/autowarefoundation/autoware:universe-planning-control-devel" \
-        --set "universe-planning-control.tags=ghcr.io/autowarefoundation/autoware:universe-planning-control" \
-        --set "universe-vehicle-system-devel.tags=ghcr.io/autowarefoundation/autoware:universe-vehicle-system-devel" \
-        --set "universe-vehicle-system.tags=ghcr.io/autowarefoundation/autoware:universe-vehicle-system" \
-        --set "universe-visualization-devel.tags=ghcr.io/autowarefoundation/autoware:universe-visualization-devel" \
-        --set "universe-visualization.tags=ghcr.io/autowarefoundation/autoware:universe-visualization" \
-        --set "universe-api-devel.tags=ghcr.io/autowarefoundation/autoware:universe-api-devel" \
-        --set "universe-api.tags=ghcr.io/autowarefoundation/autoware:universe-api" \
-        --set "universe-devel.tags=ghcr.io/autowarefoundation/autoware:universe-devel" \
-        --set "universe.tags=ghcr.io/autowarefoundation/autoware:universe" \
-        --set "universe-sensing-perception-devel-cuda.tags=ghcr.io/autowarefoundation/autoware:universe-sensing-perception-devel-cuda" \
-        --set "universe-sensing-perception-cuda.tags=ghcr.io/autowarefoundation/autoware:universe-sensing-perception-cuda" \
-        --set "universe-devel-cuda.tags=ghcr.io/autowarefoundation/autoware:universe-devel-cuda" \
-        --set "universe-cuda.tags=ghcr.io/autowarefoundation/autoware:universe-cuda" \
-        "$target$image_name_suffix"
+    if [ "$option_no_cuda" = "true" ]; then
+        # Only build base image when no CUDA is requested
+        docker buildx bake --allow=ssh --load --progress=plain -f "$SCRIPT_DIR/docker-bake-base.hcl" \
+            --set "*.context=$WORKSPACE_ROOT" \
+            --set "*.ssh=default" \
+            --set "*.platform=$platform" \
+            --set "*.args.ROS_DISTRO=$rosdistro" \
+            --set "*.args.BASE_IMAGE=$base_image" \
+            --set "*.args.SETUP_ARGS=$setup_args" \
+            --set "*.args.LIB_DIR=$lib_dir" \
+            --set "base.tags=$base_tag" \
+            base
+    else
+        # Build both base and base-cuda images
+        docker buildx bake --allow=ssh --load --progress=plain -f "$SCRIPT_DIR/docker-bake-base.hcl" \
+            --set "*.context=$WORKSPACE_ROOT" \
+            --set "*.ssh=default" \
+            --set "*.platform=$platform" \
+            --set "*.args.ROS_DISTRO=$rosdistro" \
+            --set "*.args.BASE_IMAGE=$base_image" \
+            --set "*.args.SETUP_ARGS=$setup_args" \
+            --set "*.args.LIB_DIR=$lib_dir" \
+            --set "base.tags=$base_tag" \
+            --set "base-cuda.tags=$base_cuda_tag"
+    fi
+
+    if [ "$option_no_cuda" = "true" ]; then
+        # Build only non-CUDA images
+        docker buildx bake --allow=ssh --load --progress=plain -f "$SCRIPT_DIR/docker-bake.hcl" \
+            --set "*.context=$WORKSPACE_ROOT" \
+            --set "*.ssh=default" \
+            --set "*.platform=$platform" \
+            --set "*.args.ROS_DISTRO=$rosdistro" \
+            --set "*.args.AUTOWARE_BASE_IMAGE=$autoware_base_image" \
+            --set "*.args.SETUP_ARGS=$setup_args" \
+            --set "*.args.LIB_DIR=$lib_dir" \
+            --set "universe-sensing-perception-devel.tags=ghcr.io/autowarefoundation/autoware:universe-sensing-perception-devel$main_tag_suffix" \
+            --set "universe-sensing-perception.tags=ghcr.io/autowarefoundation/autoware:universe-sensing-perception$main_tag_suffix" \
+            --set "universe-localization-mapping-devel.tags=ghcr.io/autowarefoundation/autoware:universe-localization-mapping-devel$main_tag_suffix" \
+            --set "universe-localization-mapping.tags=ghcr.io/autowarefoundation/autoware:universe-localization-mapping$main_tag_suffix" \
+            --set "universe-planning-control-devel.tags=ghcr.io/autowarefoundation/autoware:universe-planning-control-devel$main_tag_suffix" \
+            --set "universe-planning-control.tags=ghcr.io/autowarefoundation/autoware:universe-planning-control$main_tag_suffix" \
+            --set "universe-vehicle-system-devel.tags=ghcr.io/autowarefoundation/autoware:universe-vehicle-system-devel$main_tag_suffix" \
+            --set "universe-vehicle-system.tags=ghcr.io/autowarefoundation/autoware:universe-vehicle-system$main_tag_suffix" \
+            --set "universe-visualization-devel.tags=ghcr.io/autowarefoundation/autoware:universe-visualization-devel$main_tag_suffix" \
+            --set "universe-visualization.tags=ghcr.io/autowarefoundation/autoware:universe-visualization$main_tag_suffix" \
+            --set "universe-devel.tags=ghcr.io/autowarefoundation/autoware:universe-devel$main_tag_suffix" \
+            --set "universe.tags=ghcr.io/autowarefoundation/autoware:universe$main_tag_suffix" \
+            --set "core-devel.tags=ghcr.io/autowarefoundation/autoware:core-devel$main_tag_suffix" \
+            "$target$image_name_suffix"
+    else
+        # Build both CUDA and non-CUDA images
+        docker buildx bake --allow=ssh --load --progress=plain -f "$SCRIPT_DIR/docker-bake.hcl" -f "$SCRIPT_DIR/docker-bake-cuda.hcl" \
+            --set "*.context=$WORKSPACE_ROOT" \
+            --set "*.ssh=default" \
+            --set "*.platform=$platform" \
+            --set "*.args.ROS_DISTRO=$rosdistro" \
+            --set "*.args.AUTOWARE_BASE_IMAGE=$autoware_base_image" \
+            --set "*.args.AUTOWARE_BASE_CUDA_IMAGE=$autoware_base_cuda_image" \
+            --set "*.args.SETUP_ARGS=$setup_args" \
+            --set "*.args.LIB_DIR=$lib_dir" \
+            --set "universe-sensing-perception-devel.tags=ghcr.io/autowarefoundation/autoware:universe-sensing-perception-devel$main_tag_suffix" \
+            --set "universe-sensing-perception.tags=ghcr.io/autowarefoundation/autoware:universe-sensing-perception$main_tag_suffix" \
+            --set "universe-localization-mapping-devel.tags=ghcr.io/autowarefoundation/autoware:universe-localization-mapping-devel$main_tag_suffix" \
+            --set "universe-localization-mapping.tags=ghcr.io/autowarefoundation/autoware:universe-localization-mapping$main_tag_suffix" \
+            --set "universe-planning-control-devel.tags=ghcr.io/autowarefoundation/autoware:universe-planning-control-devel$main_tag_suffix" \
+            --set "universe-planning-control.tags=ghcr.io/autowarefoundation/autoware:universe-planning-control$main_tag_suffix" \
+            --set "universe-vehicle-system-devel.tags=ghcr.io/autowarefoundation/autoware:universe-vehicle-system-devel$main_tag_suffix" \
+            --set "universe-vehicle-system.tags=ghcr.io/autowarefoundation/autoware:universe-vehicle-system$main_tag_suffix" \
+            --set "universe-visualization-devel.tags=ghcr.io/autowarefoundation/autoware:universe-visualization-devel$main_tag_suffix" \
+            --set "universe-visualization.tags=ghcr.io/autowarefoundation/autoware:universe-visualization$main_tag_suffix" \
+            --set "universe-devel.tags=ghcr.io/autowarefoundation/autoware:universe-devel$main_tag_suffix" \
+            --set "universe.tags=ghcr.io/autowarefoundation/autoware:universe$main_tag_suffix" \
+            --set "universe-sensing-perception-devel-cuda.tags=ghcr.io/autowarefoundation/autoware:universe-sensing-perception-devel-cuda$main_tag_suffix" \
+            --set "universe-sensing-perception-cuda.tags=ghcr.io/autowarefoundation/autoware:universe-sensing-perception-cuda$main_tag_suffix" \
+            --set "universe-devel-cuda.tags=ghcr.io/autowarefoundation/autoware:universe-devel-cuda$main_tag_suffix" \
+            --set "universe-cuda.tags=ghcr.io/autowarefoundation/autoware:universe-cuda$main_tag_suffix" \
+            "$target$image_name_suffix"
+    fi
     set +x
 }
 
@@ -184,7 +260,9 @@ remove_dangling_images() {
 
 # Main script execution
 parse_arguments "$@"
+set_ros_distro
 set_cuda_options
+set_image_tags
 set_build_options
 set_platform
 set_arch_lib_dir

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -164,8 +164,8 @@ build_images() {
         --set "*.args.BASE_IMAGE=$base_image" \
         --set "*.args.SETUP_ARGS=$setup_args" \
         --set "*.args.LIB_DIR=$lib_dir" \
-        --set "base.tags=ghcr.io/autowarefoundation/autoware-base:latest" \
-        --set "base-cuda.tags=ghcr.io/autowarefoundation/autoware-base:cuda-latest"
+        --set "base.tags=$autoware_base_image" \
+        --set "base-cuda.tags=$autoware_base_cuda_image"
     docker buildx bake --allow=ssh --load --progress=plain -f "$SCRIPT_DIR/docker-bake.hcl" -f "$SCRIPT_DIR/docker-bake-cuda.hcl" \
         --set "*.context=$WORKSPACE_ROOT" \
         --set "*.ssh=default" \

--- a/docker/docker-bake-base.hcl
+++ b/docker/docker-bake-base.hcl
@@ -1,7 +1,7 @@
 group "default" {
   targets = [
     "base",
-    "base-cuda",
+    "base-cuda"
   ]
 }
 

--- a/docker/docker-bake-base.hcl
+++ b/docker/docker-bake-base.hcl
@@ -1,7 +1,7 @@
 group "default" {
   targets = [
     "base",
-    "base-cuda"
+    "base-cuda",
   ]
 }
 

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -20,6 +20,7 @@ print_help() {
     echo "  --download-artifacts"
     echo "                  Download artifacts"
     echo "  --module        Specify the module (default: all)"
+    echo "  --ros-distro    Specify ROS distribution (humble or jazzy, default: humble)"
     echo ""
 }
 
@@ -66,6 +67,10 @@ while [ "$1" != "" ]; do
         ;;
     --module)
         option_module="$2"
+        shift
+        ;;
+    --ros-distro)
+        option_ros_distro="$2"
         shift
         ;;
     *)
@@ -148,6 +153,11 @@ fi
 
 # Load env
 source "$SCRIPT_DIR/amd64.env"
+
+if [ "$option_ros_distro" = "jazzy" ]; then
+    source "$SCRIPT_DIR/amd64_jazzy.env"
+fi
+
 if [ "$(uname -m)" = "aarch64" ]; then
     source "$SCRIPT_DIR/arm64.env"
 fi
@@ -170,22 +180,25 @@ if ! (command -v git >/dev/null 2>&1); then
     sudo apt-get -y install git
 fi
 
-# Install pip for ansible
+# # Install pip for ansible
 if ! (python3 -m pip --version >/dev/null 2>&1); then
     sudo apt-get -y update
     sudo apt-get -y install python3-pip python3-venv
 fi
 
+# python3 -m venv --system-site-packages /opt/autoware_venv
+# source /opt/autoware_venv/bin/activate
+
 # Install pipx for ansible
 if ! (python3 -m pipx --version >/dev/null 2>&1); then
     sudo apt-get -y update
-    python3 -m pip install --user pipx
+    sudo apt-get -y install pipx
 fi
 
 # Install ansible
 python3 -m pipx ensurepath
 export PATH="${PIPX_BIN_DIR:=$HOME/.local/bin}:$PATH"
-pipx install --include-deps --force "ansible==6.*"
+pipx install --include-deps --force "ansible==10.*"
 
 # Install ansible collections
 echo -e "\e[36m"ansible-galaxy collection install -f -r "$SCRIPT_DIR/ansible-galaxy-requirements.yaml" "\e[m"

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -186,9 +186,6 @@ if ! (python3 -m pip --version >/dev/null 2>&1); then
     sudo apt-get -y install python3-pip python3-venv
 fi
 
-# python3 -m venv --system-site-packages /opt/autoware_venv
-# source /opt/autoware_venv/bin/activate
-
 # Install pipx for ansible
 if ! (python3 -m pipx --version >/dev/null 2>&1); then
     sudo apt-get -y update

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -180,7 +180,7 @@ if ! (command -v git >/dev/null 2>&1); then
     sudo apt-get -y install git
 fi
 
-# # Install pip for ansible
+# Install pip for ansible
 if ! (python3 -m pip --version >/dev/null 2>&1); then
     sudo apt-get -y update
     sudo apt-get -y install python3-pip python3-venv


### PR DESCRIPTION
## Description
This is part of https://github.com/autowarefoundation/autoware/pull/6453.
I have extracted the necessary updates for creating base image for Jazzy environment.

This includes the following modifications:
 - add autoware_jazzy.env file for setting environment variables specifically for ubuntu 24.04
 - updating autoware-base.yaml and docker-build-and-push-base.yaml to have jazzy build matrix job
   - I have replaced ./.github/workflows/load-env.yaml with falti/dotenv-action@v1 to set the environment varaibles within a same job
 - update setup-dev-env.sh to have jazzy build
   - I also updated the ansible version since version 6.* was not compatible with ubuntu 24.04 environment.

## How was this PR tested?
I have tested locally with Ubuntu 24.04 machine that ./setup-dev-env.sh works fine. 

## Notes for reviewers

None.

## Effects on system behavior

None.
