### PR TITLE
feat(docker): use autoware-tools simulator

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -174,8 +174,7 @@ services:
       - logging-simulation
 
   simulator:
-    # TODO(youtalk): Use autoware-tools:scenario-simulator image
-    image: ghcr.io/autowarefoundation/autoware:universe
+    image: ghcr.io/autowarefoundation/autoware-tools:scenario-simulator
     container_name: autoware-simulator
     pid: service:map
     ipc: host


### PR DESCRIPTION
## Description

We can use autoware-tools simulator now, as it both includes universe-simulator and tier4-scenario-simulator.

## How was this PR tested?

Tested both with planning simulation and logging simulation.

## Notes for reviewers

None.

## Effects on system behavior

None.
