### PR TITLE
docs(ansible-artifacts): make sure the user is on the correct commit

### DIFF
--- a/ansible/roles/artifacts/README.md
+++ b/ansible/roles/artifacts/README.md
@@ -8,6 +8,43 @@ Default `data_dir` location is `~/autoware_data`.
 
 ## Download instructions
 
+### Check out to the correct commit hash if necessary
+
+First check this chart if you need to change your current commit hash.
+
+```mermaid
+graph TD
+    cond1{{What is your current commit hash?}}
+    --> option_release_branch(A release tag)
+    cond1 --> opt2(main branch)
+    opt2 --> cond2{{Did you pull `autoware-nightly.repos`?}}
+    --> option_nightly(Yes)
+    cond2 --> option_autoware_main(No, I only pulled the `autoware.repos`.)
+
+    option_release_branch --> final_normal(((No need to change the commit hash, keep following the rest of the instructions. ✅)))
+    option_nightly --> final_normal
+    option_autoware_main --> final_change(((Switch to the latest release tag. 🔄)))
+
+    %% Define styles
+    classDef conditional fill:#FFF3CD,stroke:#FFB100,stroke-width:2px,color:#000,font-weight:bold;
+    classDef final_normal fill:#D4EDDA,stroke:#28A745,stroke-width:2px,color:#000,font-weight:bold;
+    classDef final_change fill:#F8D7DA,stroke:#DC3545,stroke-width:2px,color:#000,font-weight:bold;
+    classDef neutral fill:#F0F0F0,stroke:#B0B0B0,stroke-width:2px,color:#000,font-weight:normal;
+
+    %% Apply classes
+    class cond1,cond2 conditional;
+    class final_normal final_normal;
+    class final_change final_change;
+    class option_release_branch,opt2,option_nightly,option_autoware_main neutral;
+```
+
+If you need to switch to the latest tag, run the following commands:
+
+```bash
+cd ~/autoware
+git fetch --tags && git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
+```
+
 ### Requirements
 
 Install ansible following the instructions in the [ansible installation guide](../../README.md#ansible-installation).

--- a/ansible/roles/artifacts/README.md
+++ b/ansible/roles/artifacts/README.md
@@ -45,6 +45,8 @@ cd ~/autoware
 git fetch --tags && git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
 ```
 
+Once you've downloaded the artifacts, you can switch back to your desired branch or commit hash.
+
 ### Requirements
 
 Install ansible following the instructions in the [ansible installation guide](../../README.md#ansible-installation).


### PR DESCRIPTION
## Description

This PR adds a short guide to help users pick the correct commit hash when setting up Autoware.
It explains what to do if the **main branch** and `.repos` file become incompatible, using a small decision chart and example commands.
The goal is to reduce setup issues for new users and ensure consistent builds.

Raised by @amadeuszsz 🙏

<img width="937" height="955" alt="image" src="https://github.com/user-attachments/assets/06dbd3f1-1d20-45ca-b840-f337e4a33b87" />

## How was this PR tested?

* Verified the Mermaid chart renders correctly in GitHub preview.
* Checked that the example `git` command works in a clean workspace.

## Notes for reviewers

Please review the clarity of the wording and the chart layout.

## Effects on system behavior

None, documentation-only change.