### PR TITLE
ci: add latest-jazzy tag for base image

### DIFF
--- a/.github/actions/docker-build-and-push-base/action.yaml
+++ b/.github/actions/docker-build-and-push-base/action.yaml
@@ -44,6 +44,7 @@ runs:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
         tags: |
           type=raw,value=${{ steps.date.outputs.date }}${{ inputs.suffix }}
+          type=raw,value=latest${{ inputs.suffix }}
         bake-target: docker-metadata-action-base
         flavor: |
           latest=${{ inputs.set-latest }}


### PR DESCRIPTION
## Description
This adds latest-jazzy tag to the base image for Jazzy build.
Currently, autoware-base workflow only creates the image with date prefix as in http://github.com/autowarefoundation/autoware/pkgs/container/autoware-base/570440528?tag=20251108-jazzy.

This PR also adds latest-jazzy tag to the same image so that users can always refer to the latest image.

## How was this PR tested?
I have tested in my forked branch. The test is done in this [action](https://github.com/mitsudome-r/autoware/actions/runs/19162865442) and the generated image is uploaded [here](https://github.com/mitsudome-r/autoware/pkgs/container/autoware-base/569390773?tag=latest-jazzy) 
## Notes for reviewers

None.

## Effects on system behavior

None.
