### PR TITLE
ci: update backport workflow to request review from original author

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -28,6 +28,27 @@ jobs:
           private_key: ${{ secrets.PRIVATE_KEY }}
 
       - uses: tibdex/backport@v2
+        id: backport
         with:
           github_token: ${{ steps.generate-token.outputs.token }}
           title_template: "<%= title %> (backport #<%= number %>)"
+
+      - name: Request review from original author
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          PR_JSON: ${{ steps.backport.outputs.created_pull_requests }}
+          ORIGINAL_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          echo "Created PRs JSON: $PR_JSON"
+          echo "Original PR Author: $ORIGINAL_AUTHOR"
+
+          # Use 'jq' to parse the JSON and extract all PR numbers (values)
+          # Loop through the extracted PR numbers, one per line
+          echo "$PR_JSON" | jq -r 'to_entries | .[] | .value' | while read -r pr_num; do
+            if [ -n "$pr_num" ]; then
+              echo "Requesting review for PR #$pr_num from $ORIGINAL_AUTHOR..."
+
+              # Use the 'gh' CLI to add the reviewer
+              gh pr edit "$pr_num" --add-reviewer "$ORIGINAL_AUTHOR" --repo "${{ github.repository }}"
+            fi
+          done


### PR DESCRIPTION
Closing this due to the missing `Signed-off-by` issue. An identical PR is opened as #6583 .

## Description
Add a review request step for original author after backporting via `.github/workflows/backport.yaml`,
so that the author is reminded to properly review and sync backported PRs into the target branch.

## How was this PR tested?

1. Merged the PR https://github.com/paulsohn/autoware/pull/2 from `paulsohn:foo` -> `paulsohn:test-backport`, with tag `backport test-backport-1` and `backport test-backport-2`; all of them have this updated workflow.
2. My github app (set to provide `APP_ID` and `PRIVATE_KEY`) generated two backport PRs
 https://github.com/paulsohn/autoware/pull/4 (onto `paulsohn:test-backport-1`) and https://github.com/paulsohn/autoware/pull/3 (onto `paulsohn:test-backport-2`)

## Notes for reviewers

The `output.created_pull_requests` of `tibdex/backport` follows the below structure:
```json
{
    "branch1": 1111, // Backport PR no. for branch1
    "branch2": 2222 // Backport PR no. for branch2
}
```

## Effects on system behavior

None.
