### PR TITLE
ci: add `backport.yaml` to sync-file list, updating to request review from original author

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -7,6 +7,7 @@
     - source: .github/dependabot.yaml
     - source: .github/pull_request_template.md
     - source: .github/stale.yml
+    - source: .github/workflows/backport.yaml
     - source: .github/workflows/cancel-previous-workflows.yaml
     - source: .github/workflows/comment-on-pr.yaml
     - source: .github/workflows/github-release.yaml

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -28,6 +28,27 @@ jobs:
           private_key: ${{ secrets.PRIVATE_KEY }}
 
       - uses: tibdex/backport@v2
+        id: backport
         with:
           github_token: ${{ steps.generate-token.outputs.token }}
           title_template: "<%= title %> (backport #<%= number %>)"
+
+      - name: Request review from original author
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          PR_JSON: ${{ steps.backport.outputs.created_pull_requests }}
+          ORIGINAL_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          echo "Created PRs JSON: $PR_JSON"
+          echo "Original PR Author: $ORIGINAL_AUTHOR"
+
+          # Use 'jq' to parse the JSON and extract all PR numbers (values)
+          # Loop through the extracted PR numbers, one per line
+          echo "$PR_JSON" | jq -r 'to_entries | .[] | .value' | while read -r pr_num; do
+            if [ -n "$pr_num" ]; then
+              echo "Requesting review for PR #$pr_num from $ORIGINAL_AUTHOR..."
+
+              # Use the 'gh' CLI to add the reviewer
+              gh pr edit "$pr_num" --add-reviewer "$ORIGINAL_AUTHOR" --repo "${{ github.repository }}"
+            fi
+          done

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -28,27 +28,6 @@ jobs:
           private_key: ${{ secrets.PRIVATE_KEY }}
 
       - uses: tibdex/backport@v2
-        id: backport
         with:
           github_token: ${{ steps.generate-token.outputs.token }}
           title_template: "<%= title %> (backport #<%= number %>)"
-
-      - name: Request review from original author
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-          PR_JSON: ${{ steps.backport.outputs.created_pull_requests }}
-          ORIGINAL_AUTHOR: ${{ github.event.pull_request.user.login }}
-        run: |
-          echo "Created PRs JSON: $PR_JSON"
-          echo "Original PR Author: $ORIGINAL_AUTHOR"
-
-          # Use 'jq' to parse the JSON and extract all PR numbers (values)
-          # Loop through the extracted PR numbers, one per line
-          echo "$PR_JSON" | jq -r 'to_entries | .[] | .value' | while read -r pr_num; do
-            if [ -n "$pr_num" ]; then
-              echo "Requesting review for PR #$pr_num from $ORIGINAL_AUTHOR..."
-
-              # Use the 'gh' CLI to add the reviewer
-              gh pr edit "$pr_num" --add-reviewer "$ORIGINAL_AUTHOR" --repo "${{ github.repository }}"
-            fi
-          done


### PR DESCRIPTION
## Description
Add a review request step for original author after backporting via `.github/workflows/backport.yaml`,
so that the author is reminded to properly review and sync backported PRs into the target branch.

**Edit**: the actual update will be added by syncing https://github.com/autowarefoundation/sync-file-templates/pull/40 . The only direct change from this PR is to add `backport.yaml` into sync-files list.

## How was this PR tested?

1. ~~Merged the PR https://github.com/paulsohn/autoware/pull/2 from `paulsohn:foo` -> `paulsohn:test-backport`, with tag `backport test-backport-1` and `backport test-backport-2`; all of them have this updated workflow.~~
2. ~~My github app (set to provide `APP_ID` and `PRIVATE_KEY`) generated two backport PRs
 https://github.com/paulsohn/autoware/pull/4 (onto `paulsohn:test-backport-1`) and https://github.com/paulsohn/autoware/pull/3 (onto `paulsohn:test-backport-2`)~~

**Edit**: Obsolote, see https://github.com/autowarefoundation/sync-file-templates/pull/40 .

## Notes for reviewers

The `output.created_pull_requests` of `tibdex/backport` follows the below structure:
```json
{
    "branch1": 1111, // Backport PR no. for branch1
    "branch2": 2222 // Backport PR no. for branch2
}
```

The backport workflow is introduced in https://github.com/autowarefoundation/autoware/pull/2856 , presumably to support TIER IV branch convention. Although AWF Autoware itself does not have such convention, this PR is beneficial to everyone depending on this workflow.

## Effects on system behavior

None.
