### PR TITLE
chore: remove ansible venv that was created via pipx

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean \
 RUN --mount=type=ssh \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   ./setup-dev-env.sh -y rosdep \
-  && pip uninstall -y ansible ansible-core \
+  && pipx uninstall ansible \
   && /autoware/cleanup_apt.sh
 
 # Generate install package lists


### PR DESCRIPTION
## Description

This PR removes the `ansible` venv that was created via `pipx` in the `setup-dev-env.sh` script. See https://github.com/autowarefoundation/autoware_universe/issues/11663

Part of https://github.com/autowarefoundation/autoware_universe/issues/11670

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
