### PR TITLE
chore: strip unneeded symbols from binaries and shared libraries

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -525,6 +525,9 @@ COPY --from=universe-vehicle-system-devel /opt/autoware /opt/autoware
 COPY --from=universe-visualization-devel /opt/autoware /opt/autoware
 COPY --from=universe-api-devel /opt/autoware /opt/autoware
 
+# strip unneeded symbols from binaries in /opt/autoware
+RUN find /opt/autoware -type f \( -executable -o -name "*.so" \) -exec strip --strip-unneeded --remove-section=.comment --remove-section=.note {} \;
+
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target="${CCACHE_DIR}" \
   --mount=type=bind,source=src/sensor_component,target=/autoware/src/sensor_component \


### PR DESCRIPTION
## Description

This PR strips all binaries and shared libraries in /opt/autoware of all the unnecessary symbols.

Before calling `strip --strip-unneeded`:

```sh
# du -csh /opt/autoware/
1.1G	/opt/autoware/
1.1G	total
```

After calling `strip --strip-unneeded`:

```sh
# du -csh /opt/autoware/
805M	/opt/autoware/
805M	total
```

Part of https://github.com/autowarefoundation/autoware_universe/issues/11670

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
