### PR TITLE
feat(autoware.repos): bump version for autoware_core and autoware_universe

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -27,16 +27,16 @@ repositories:
   core/autoware_core:
     type: git
     url: https://github.com/autowarefoundation/autoware_core.git
-    version: 1.4.0
+    version: 1.5.0
   core/autoware_rviz_plugins:
     type: git
     url: https://github.com/autowarefoundation/autoware_rviz_plugins.git
-    version: 0.2.0
+    version: 0.3.0
   # universe
   universe/autoware_universe:
     type: git
     url: https://github.com/autowarefoundation/autoware_universe.git
-    version: 0.47.1
+    version: 0.48.0
   universe/external/tier4_ad_api_adaptor: # TODO(TIER IV): Migrate to AD API and remove this repository entry.
     type: git
     url: https://github.com/tier4/tier4_ad_api_adaptor.git
@@ -44,7 +44,7 @@ repositories:
   universe/external/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git
-    version: v0.51.0
+    version: v0.58.0
   # Fix the version not to merge https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs/pull/9
   universe/external/morai_msgs:
     type: git
@@ -98,7 +98,7 @@ repositories:
   launcher/autoware_launch:
     type: git
     url: https://github.com/autowarefoundation/autoware_launch.git
-    version: 0.47.0
+    version: 0.48.0
   # sensor_component
   sensor_component/external/sensor_component_description:
     type: git


### PR DESCRIPTION
## Description
resolves https://github.com/autowarefoundation/autoware/issues/6577
This PR updates autoware_core and autoware_unvierse. I've also updated the tags for dependent repositories as well to pass the build. 

## How was this PR tested?

I have done:
* build test
* planning simulator tutorail
* rosbag simulator tutorial

## Notes for reviewers

It would be nice if reviewers could also confirm that this update won't break the tutorials.

## Effects on system behavior

None.
