### PR TITLE
fix: jazzy docker build no-tag error

### DIFF
--- a/docker/docker-bake-base.hcl
+++ b/docker/docker-bake-base.hcl
@@ -1,15 +1,13 @@
 group "default" {
   targets = [
     "base",
-    "base-cuda",
-    "jazzy-base"
+    "base-cuda"
   ]
 }
 
 // For docker/metadata-action
 target "docker-metadata-action-base" {}
 target "docker-metadata-action-base-cuda" {}
-target "docker-metadata-action-base-jazzy" {}
 
 target "base" {
   inherits = ["docker-metadata-action-base"]
@@ -21,14 +19,4 @@ target "base-cuda" {
   inherits = ["docker-metadata-action-base-cuda"]
   dockerfile = "docker/Dockerfile.base"
   target = "base-cuda"
-}
-
-target "jazzy-base" {
-  inherits = ["docker-metadata-action-base-jazzy"]
-  dockerfile = "docker/Dockerfile.base"
-  target = "base"
-  args = {
-    ROS_DISTRO = "jazzy"
-    BASE_IMAGE = "ros:jazzy-ros-base-noble"
-  }
 }


### PR DESCRIPTION
## Description

fix docker build ci error in this [pr](https://github.com/autowarefoundation/autoware/pull/6453)

[github action error link](https://github.com/autowarefoundation/autoware/actions/runs/19469267615/job/55711831501#step:6:1192) 

<img width="1486" height="752" alt="图片" src="https://github.com/user-attachments/assets/37af1a6c-b0f3-4600-bed1-b7eff043c886" />

### Solution
fix by remove jazzy-base target in file docker-bake-base.hcl, since jazzy suffix in autoware-base.yaml will pass down to this file to make docker image `ghcr.io/autowarefoundation/autoware-base:latest-jazzy`

<img width="500" height="702" alt="Screenshot from 2025-11-19 13-56-44" src="https://github.com/user-attachments/assets/4e675dca-d9e8-4522-ac39-21780c3ca654" />

parent issue link -- https://github.com/autowarefoundation/autoware_core/issues/623
## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
