### PR TITLE
chore: remove /opt/autoware from the Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,8 @@ RUN --mount=type=ssh \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   ./setup-dev-env.sh -y rosdep --ros-distro "$ROS_DISTRO" \
   && pipx uninstall ansible\
-  && /autoware/cleanup_apt.sh
+  && /autoware/cleanup_apt.sh \
+  && rm -rf /opt/autoware
 
 # Generate install package lists
 COPY src/core/autoware_adapi_msgs /autoware/src/core/autoware_adapi_msgs


### PR DESCRIPTION
## Description

This PR removes the `/opt/autoware` folder as it's not actually used in CI.

Part of https://github.com/autowarefoundation/autoware_universe/issues/11670

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
