### PR TITLE
fix(ansible): pub key storing location for agnocast ppa package

### DIFF
--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -55,14 +55,15 @@
     msg: "GPG key fingerprint verified successfully: CFDB1950382092423DF37D3E075CD8B5C91E5ACA"
 
 - name: Add agnocast repository
-  ansible.builtin.deb822_repository:
-    name: agnocast
-    types: deb
-    uris: http://ppa.launchpad.net/t4-system-software/agnocast/ubuntu
-    suites: jammy
-    components: main
-    signed_by: /etc/apt/keyrings/agnocast-ppa.gpg
-    state: present
+  ansible.builtin.copy:
+    dest: /etc/apt/sources.list.d/agnocast.sources
+    content: |
+      Types: deb
+      URIs: http://ppa.launchpad.net/t4-system-software/agnocast/ubuntu
+      Suites: jammy
+      Components: main
+      Signed-By: /etc/apt/keyrings/agnocast-ppa.gpg
+    mode: "0644"
   become: true
 
 - name: Restore original IPv6 settings # noqa: no-changed-when

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -18,11 +18,48 @@
     - { name: net.ipv6.conf.default.disable_ipv6 }
   become: true
 
-- name: Add agnocast PPA repository while IPv6 is disabled
-  ansible.builtin.apt_repository:
-    repo: ppa:t4-system-software/agnocast
+- name: Create /etc/apt/keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+  become: true
+
+- name: Download agnocast PPA GPG key while IPv6 is disabled
+  ansible.builtin.get_url:
+    url: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xCFDB1950382092423DF37D3E075CD8B5C91E5ACA
+    dest: /tmp/agnocast-ppa.asc
+    mode: "0644"
+  register: agnocast_gpg_key_download
+
+- name: Convert GPG key to binary format and install
+  ansible.builtin.shell: |
+    gpg --dearmor < /tmp/agnocast-ppa.asc > /etc/apt/keyrings/agnocast-ppa.gpg
+    chmod 0644 /etc/apt/keyrings/agnocast-ppa.gpg
+  become: true
+  when: agnocast_gpg_key_download.changed
+  changed_when: true
+
+- name: Verify GPG key fingerprint
+  ansible.builtin.shell: |
+    gpg --show-keys /etc/apt/keyrings/agnocast-ppa.gpg | grep -q 'CFDB1950382092423DF37D3E075CD8B5C91E5ACA'
+  register: agnocast_gpg_verify
+  failed_when: agnocast_gpg_verify.rc != 0
+  changed_when: false
+
+- name: Display GPG key verification success
+  ansible.builtin.debug:
+    msg: "GPG key fingerprint verified successfully: CFDB1950382092423DF37D3E075CD8B5C91E5ACA"
+
+- name: Add agnocast repository (deb822 format)
+  ansible.builtin.deb822_repository:
+    name: agnocast
+    types: deb
+    uris: http://ppa.launchpad.net/t4-system-software/agnocast/ubuntu
+    suites: jammy
+    components: main
+    signed_by: /etc/apt/keyrings/agnocast-ppa.gpg
     state: present
-    update_cache: false
   become: true
 
 - name: Restore original IPv6 settings # noqa: no-changed-when

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -36,13 +36,16 @@
   ansible.builtin.shell: |
     gpg --dearmor < /tmp/agnocast-ppa.asc > /etc/apt/keyrings/agnocast-ppa.gpg
     chmod 0644 /etc/apt/keyrings/agnocast-ppa.gpg
+  args:
+    creates: /etc/apt/keyrings/agnocast-ppa.gpg
   become: true
-  when: agnocast_gpg_key_download.changed
-  changed_when: true
 
 - name: Verify GPG key fingerprint
   ansible.builtin.shell: |
+    set -o pipefail
     gpg --show-keys /etc/apt/keyrings/agnocast-ppa.gpg | grep -q 'CFDB1950382092423DF37D3E075CD8B5C91E5ACA'
+  args:
+    executable: /bin/bash
   register: agnocast_gpg_verify
   failed_when: agnocast_gpg_verify.rc != 0
   changed_when: false

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -1,3 +1,27 @@
+# Remove legacy agnocast PPA configuration (if exists)
+- name: Remove legacy agnocast PPA via add-apt-repository
+  ansible.builtin.command: add-apt-repository --remove ppa:t4-system-software/agnocast -y
+  register: agnocast_legacy_ppa_remove
+  failed_when: false
+  changed_when: agnocast_legacy_ppa_remove.rc == 0
+  become: true
+
+- name: Remove legacy agnocast sources.list files
+  ansible.builtin.shell: rm -f /etc/apt/sources.list.d/*agnocast*.list
+  args:
+    executable: /bin/bash
+  register: agnocast_legacy_sources_remove
+  changed_when: false
+  become: true
+
+- name: Remove legacy agnocast GPG keys from trusted.gpg.d
+  ansible.builtin.shell: rm -f /etc/apt/trusted.gpg.d/*agnocast*.gpg
+  args:
+    executable: /bin/bash
+  register: agnocast_legacy_gpg_remove
+  changed_when: false
+  become: true
+
 # TODO(rej55, sykwer): IPv6 support
 - name: Save current IPv6 settings
   ansible.builtin.shell: |

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -51,7 +51,7 @@
   ansible.builtin.debug:
     msg: "GPG key fingerprint verified successfully: CFDB1950382092423DF37D3E075CD8B5C91E5ACA"
 
-- name: Add agnocast repository (deb822 format)
+- name: Add agnocast repository
   ansible.builtin.deb822_repository:
     name: agnocast
     types: deb


### PR DESCRIPTION
## Description
### Summary

  This PR updates the Agnocast PPA repository configuration to use the modern DEB822 format (.sources file) with explicit GPG key signing.

### Changes

  - Remove legacy Agnocast PPA configuration automatically before setup (old .list files and GPG keys)
  - Create /etc/apt/keyrings directory for storing GPG keys
  - Download and install the Agnocast PPA GPG key to /etc/apt/keyrings/agnocast-ppa.gpg
  - Add GPG key fingerprint verification for security
  - Configure the repository using DEB822 format with explicit Signed-By directive

### Migration Issue Notice
The Ansible playbook automatically removes any legacy Agnocast PPA configuration before setting up the new format. This includes:

  1. Removing the PPA via add-apt-repository --remove
  2. Removing old /etc/apt/sources.list.d/*agnocast*.list files
  3. Removing old /etc/apt/trusted.gpg.d/*agnocast*.gpg keys

  This prevents the following conflict error that previously occurred when both old and new configurations coexisted:

```
  TASK [autoware.dev_env.agnocast : Update apt cache] ************************************************************************************************************************************************************************************************************
  fatal: [localhost]: FAILED! => {"changed": false, "msg": "E:Conflicting values set for option Signed-By regarding source http://ppa.launchpad.net/t4-system-software/agnocast/ubuntu/ jammy: /etc/apt/keyrings/agnocast-ppa.gpg != , E:The list of sources could not be read."}
```

## How was this PR tested?
```
TASK [autoware.dev_env.agnocast : Remove legacy agnocast PPA via add-apt-repository] ********************************************************************************************************************************************************************************************************************************************************************************************************************************************
changed: [localhost]

TASK [autoware.dev_env.agnocast : Remove legacy agnocast sources.list files] ****************************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [autoware.dev_env.agnocast : Remove legacy agnocast GPG keys from trusted.gpg.d] *******************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [autoware.dev_env.agnocast : Save current IPv6 settings] *******************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [autoware.dev_env.agnocast : Temporarily disable IPv6] *********************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => (item={'name': 'net.ipv6.conf.all.disable_ipv6'})
ok: [localhost] => (item={'name': 'net.ipv6.conf.default.disable_ipv6'})

TASK [autoware.dev_env.agnocast : Create /etc/apt/keyrings directory] ***********************************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [autoware.dev_env.agnocast : Download agnocast PPA GPG key while IPv6 is disabled] *****************************************************************************************************************************************************************************************************************************************************************************************************************************************
changed: [localhost]

TASK [autoware.dev_env.agnocast : Convert GPG key to binary format and install] *************************************************************************************************************************************************************************************************************************************************************************************************************************************************
changed: [localhost]

TASK [autoware.dev_env.agnocast : Verify GPG key fingerprint] *******************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [autoware.dev_env.agnocast : Display GPG key verification success] *********************************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "GPG key fingerprint verified successfully: CFDB1950382092423DF37D3E075CD8B5C91E5ACA"
}

TASK [autoware.dev_env.agnocast : Add agnocast repository] **********************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
changed: [localhost]

TASK [autoware.dev_env.agnocast : Restore original IPv6 settings] ***************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
skipping: [localhost] => (item=net.ipv6.conf.all.disable_ipv6 = 1) 
skipping: [localhost] => (item=net.ipv6.conf.default.disable_ipv6 = 1) 
skipping: [localhost]

TASK [autoware.dev_env.agnocast : Update apt cache] *****************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
changed: [localhost]

TASK [autoware.dev_env.agnocast : Install agnocast-heaphook-v2.1.2] *************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [autoware.dev_env.agnocast : Check if running in a container using systemd-detect-virt] ************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [autoware.dev_env.agnocast : Set container environment fact] ***************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [autoware.dev_env.agnocast : Display environment detection result] *********************************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "Running in container: False (detected: none)"
}

TASK [autoware.dev_env.agnocast : Display info when skipping agnocast-kmod in container] ****************************************************************************************************************************************************************************************************************************************************************************************************************************************
skipping: [localhost]

TASK [autoware.dev_env.agnocast : Check if linux-headers package is available] **************************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [autoware.dev_env.agnocast : Display warning if linux-headers is not available] ********************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "WARNING: linux-headers-6.8.1+ package not found. The agnocast-kmod installation may fail. Please manually install the kernel headers and re-run this role."
}

TASK [autoware.dev_env.agnocast : Install linux headers for the running kernel] *************************************************************************************************************************************************************************************************************************************************************************************************************************************************
skipping: [localhost]

TASK [autoware.dev_env.agnocast : Display warning if linux-headers installation failed] *****************************************************************************************************************************************************************************************************************************************************************************************************************************************
skipping: [localhost]

TASK [autoware.dev_env.agnocast : Check if agnocast-kmod is installed in dkms with version v2.1.2] ******************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [autoware.dev_env.agnocast : Purge agnocast-kmod if not found in dkms for version v2.1.2] **********************************************************************************************************************************************************************************************************************************************************************************************************************************
skipping: [localhost]

TASK [autoware.dev_env.agnocast : Install agnocast-kmod if not found in dkms for version v2.1.2] ********************************************************************************************************************************************************************************************************************************************************************************************************************************
skipping: [localhost]

TASK [autoware.dev_env.agnocast : Display warning if agnocast-kmod installation failed] *****************************************************************************************************************************************************************************************************************************************************************************************************************************************
skipping: [localhost]

TASK [autoware.dev_env.agnocast : Ensure agnocast module is loaded at boot via modules-load.d] **********************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost]


```

## Notes for reviewers

None.

## Effects on system behavior

None.
