### PR TITLE
ci: disable installing extra APT packages

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -14,6 +14,10 @@ COPY docker/scripts/cleanup_system.sh /autoware/cleanup_system.sh
 RUN chmod +x /autoware/cleanup_system.sh
 WORKDIR /autoware
 
+# Disable installing suggested and recommended packages
+RUN echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/99-disable-extra-packages
+RUN echo 'APT::Install-Suggests "false";' >> /etc/apt/apt.conf.d/99-disable-extra-packages
+
 # Install apt packages and add GitHub to known hosts for private repositories
 RUN rm -f /etc/apt/apt.conf.d/docker-clean \
   && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -15,8 +15,8 @@ RUN chmod +x /autoware/cleanup_system.sh
 WORKDIR /autoware
 
 # Disable installing suggested and recommended packages
-RUN echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/99-disable-extra-packages
-RUN echo 'APT::Install-Suggests "false";' >> /etc/apt/apt.conf.d/99-disable-extra-packages
+RUN echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/99-disable-extra-packages; \
+    echo 'APT::Install-Suggests "false";' >> /etc/apt/apt.conf.d/99-disable-extra-packages
 
 # Install apt packages and add GitHub to known hosts for private repositories
 RUN rm -f /etc/apt/apt.conf.d/docker-clean \


### PR DESCRIPTION
## Description

This PR disables installing recommended and suggested packages when installing a package via APT

Part of https://github.com/autowarefoundation/autoware_universe/issues/11670

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
