### PR TITLE
fix(web-auto-ci): ignore comments in env file

### DIFF
--- a/.webauto-ci/main/autoware-setup/run.sh
+++ b/.webauto-ci/main/autoware-setup/run.sh
@@ -13,9 +13,9 @@ while read -r env_name value; do
     ansible_args+=("--extra-vars" "${env_name}=${!env_name}")
 done < <(
     grep -v '^\s*#' amd64.env |
-    grep -v '^\s*$' |
-    sed 's/#.*//' |      # remove trailing comments
-    sed 's/=.*//'        # extract variable name
+        grep -v '^\s*$' |
+        sed 's/#.*//' | # remove trailing comments
+        sed 's/=.*//'   # extract variable name
 )
 
 ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"

--- a/.webauto-ci/main/autoware-setup/run.sh
+++ b/.webauto-ci/main/autoware-setup/run.sh
@@ -9,7 +9,7 @@ ansible_args+=("--extra-vars" "install_devel=false")
 
 # read amd64 env file and expand ansible arguments
 source 'amd64.env'
-while read -r env_name value; do
+while read -r env_name; do
     ansible_args+=("--extra-vars" "${env_name}=${!env_name}")
 done < <(
     grep -v '^\s*#' amd64.env |

--- a/.webauto-ci/main/autoware-setup/run.sh
+++ b/.webauto-ci/main/autoware-setup/run.sh
@@ -9,9 +9,14 @@ ansible_args+=("--extra-vars" "install_devel=false")
 
 # read amd64 env file and expand ansible arguments
 source 'amd64.env'
-while read -r env_name; do
+while read -r env_name value; do
     ansible_args+=("--extra-vars" "${env_name}=${!env_name}")
-done < <(sed "s/=.*//" <amd64.env)
+done < <(
+    grep -v '^\s*#' amd64.env |
+    grep -v '^\s*$' |
+    sed 's/#.*//' |      # remove trailing comments
+    sed 's/=.*//'        # extract variable name
+)
 
 ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"
 ansible-playbook "ansible/playbooks/universe.yaml" \


### PR DESCRIPTION
## Description
run.sh script used for .webauto-ci parses the env file to setup the CI in evaluator.
When we did Jazzy porting, we started to add comments to our amd64.env, and this is now causing the error.
The PR will skip the comment in env file before parsing it.

## How was this PR tested?
Failed Job: https://evaluation.ci.tier4.jp/evaluation/reports/692da4f4-b00f-500d-88b0-30663aa07dc2?project_id=awf
Successful Evaluation Job after modification: https://evaluation.ci.tier4.jp/evaluation/reports/7c44c183-49a9-5661-81bf-e93d3c4f51c3?project_id=awf

## Notes for reviewers

None.

## Effects on system behavior

None.
