### PR TITLE
chore: simplify issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/simple-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/simple-issue.yaml
@@ -1,0 +1,19 @@
+name: Task
+description: Plan a task
+body:
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      description: Confirm the following items before proceeding. If one cannot be satisfied, create a discussion thread instead.
+      options:
+        - label: I've read the [contribution guidelines](https://github.com/autowarefoundation/autoware/blob/main/CONTRIBUTING.md).
+          required: true
+        - label: I've searched other issues and no duplicate issues were found.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: Write a brief description of the issue.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/simple-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/simple-issue.yaml
@@ -1,5 +1,5 @@
-name: Task
-description: Plan a task
+name: Simple Issue
+description: Create a simple issue
 body:
   - type: checkboxes
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,3 @@
 ## Description
 
 ## How was this PR tested?
-
-## Notes for reviewers
-
-None.
-
-## Effects on system behavior
-
-None.


### PR DESCRIPTION
## Description

This PR simplifies the templates:
- Add simple issue option.
- Remove the **Notes for reviewers** and **Effects on system behavior** from the PR template.

## How was this PR tested?

- https://github.com/autowarefoundation/autoware-documentation/pull/735 same as this, tested there.

<img width="1211" height="828" alt="image" src="https://github.com/user-attachments/assets/7f6ce722-1835-484d-98ee-2d0daf2570b8" />

<img width="741" height="643" alt="image" src="https://github.com/user-attachments/assets/bc1e6cd5-5da4-49a8-bb20-a398304e524c" />


## Notes for reviewers

None.

## Effects on system behavior

None.
