### PR TITLE
revert: ci: disable installing extra APT packages (#6608)

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -14,10 +14,6 @@ COPY docker/scripts/cleanup_system.sh /autoware/cleanup_system.sh
 RUN chmod +x /autoware/cleanup_system.sh
 WORKDIR /autoware
 
-# Disable installing suggested and recommended packages
-RUN echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/99-disable-extra-packages; \
-    echo 'APT::Install-Suggests "false";' >> /etc/apt/apt.conf.d/99-disable-extra-packages
-
 # Install apt packages and add GitHub to known hosts for private repositories
 RUN rm -f /etc/apt/apt.conf.d/docker-clean \
   && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache


### PR DESCRIPTION
This reverts commit 6a89cc8bccdc6781cff4cbc21c39064a998f5800.

- Until https://github.com/autowarefoundation/autoware/pull/6608#issuecomment-3638601872 is fixed, we should revert this because the images are not building right now.