### PR TITLE
revert: revert: ci: disable installing extra APT packages (#6608) (#6639)

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -14,6 +14,10 @@ COPY docker/scripts/cleanup_system.sh /autoware/cleanup_system.sh
 RUN chmod +x /autoware/cleanup_system.sh
 WORKDIR /autoware
 
+# Disable installing suggested and recommended packages
+RUN echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/99-disable-extra-packages; \
+    echo 'APT::Install-Suggests "false";' >> /etc/apt/apt.conf.d/99-disable-extra-packages
+
 # Install apt packages and add GitHub to known hosts for private repositories
 RUN rm -f /etc/apt/apt.conf.d/docker-clean \
   && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache


### PR DESCRIPTION
This reverts commit 31a0a476ee208456ef8c0d631310a2c131d34e9c.

- See for the cause: https://github.com/autowarefoundation/autoware/pull/6639#issuecomment-3646038267

In summary, the build failure was from some other issue (spconv download being flaky).