### PR TITLE
feat: switch from vcstool to vcs2l

### DIFF
--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install jq and vcstool
+    - name: Install jq and vcs2l
       run: |
         sudo apt-get -y update
         sudo apt-get -y install curl gnupg lsb-release
@@ -30,7 +30,7 @@ runs:
           sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
 
         sudo apt-get update
-        sudo apt-get install -y jq python3-pip python3-vcstool
+        sudo apt-get install -y jq python3-pip python3-vcs2l
       shell: bash
 
     - name: Run vcs import

--- a/.github/actions/docker-build-and-push-tools/action.yaml
+++ b/.github/actions/docker-build-and-push-tools/action.yaml
@@ -19,11 +19,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install jq and vcstool
+    - name: Install jq and vcs2l
       run: |
         sudo apt-get -y update
         sudo apt-get -y install jq python3-pip
-        pip install --no-cache-dir vcstool
+        pip install --no-cache-dir vcs2l
       shell: bash
 
     - name: Run vcs import

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -32,11 +32,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install jq and vcstool
+    - name: Install jq and vcs2l
       run: |
         sudo apt-get -y update
         sudo apt-get -y install jq python3-pip
-        pip install --no-cache-dir vcstool
+        pip install --no-cache-dir vcs2l
       shell: bash
 
     - name: Run vcs import

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -22,11 +22,11 @@ runs:
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Install vcstool
+    - name: Install vcs2l
       run: |
         sudo apt-get -y update
         sudo apt-get -y install python3-pip
-        pipx install vcstool
+        pipx install vcs2l
       shell: bash
 
     - name: Run vcs import

--- a/.github/workflows/scenario-test.yaml
+++ b/.github/workflows/scenario-test.yaml
@@ -26,7 +26,7 @@ jobs:
             lsb-release \
             python3-pip \
             git
-          pip install --upgrade gdown vcstool
+          pip install --upgrade gdown vcs2l
       - name: Show memory info
         shell: bash
         run: free -h

--- a/ansible/roles/ros2_dev_tools/README.md
+++ b/ansible/roles/ros2_dev_tools/README.md
@@ -15,7 +15,6 @@ sudo apt update && sudo apt install -y \
   python3-flake8-docstrings \
   python3-pip \
   python3-pytest-cov \
-  ros-dev-tools \
   python3-flake8-blind-except \
   python3-flake8-builtins \
   python3-flake8-class-newline \
@@ -24,7 +23,14 @@ sudo apt update && sudo apt install -y \
   python3-flake8-import-order \
   python3-flake8-quotes \
   python3-pytest-repeat \
-  python3-pytest-rerunfailures
+  python3-pytest-rerunfailures \
+  ros-build-essential \
+  python3-bloom \
+  python3-colcon-common-extensions \
+  python3-colcon-mixin \
+  python3-rosdep \
+  python3-vcs2l \
+  wget
 
 # Initialize rosdep
 sudo rosdep init

--- a/ansible/roles/ros2_dev_tools/tasks/main.yaml
+++ b/ansible/roles/ros2_dev_tools/tasks/main.yaml
@@ -6,7 +6,6 @@
       - python3-flake8-docstrings
       - python3-pip
       - python3-pytest-cov
-      - ros-dev-tools
       - python3-flake8-blind-except
       - python3-flake8-builtins
       - python3-flake8-class-newline
@@ -16,6 +15,13 @@
       - python3-flake8-quotes
       - python3-pytest-repeat
       - python3-pytest-rerunfailures
+      - ros-build-essential # from ros-dev-tools
+      - python3-bloom # from ros-dev-tools
+      - python3-colcon-common-extensions # from ros-dev-tools
+      - python3-colcon-mixin # from ros-dev-tools
+      - python3-rosdep # from ros-dev-tools
+      - python3-vcs2l # formerly python3-vcstool
+      - wget # from ros-dev-tools
     state: latest
     update_cache: true
 


### PR DESCRIPTION
- Relevant Discussion: #6645

---

- https://github.com/dirk-thomas/vcstool is no longer maintained.
- https://github.com/ros-infrastructure/vcs2l is its alternative maintained by the ROS team. It's a fork and drop-in replacement.

## Manual developer tips

### If you have `ros-dev-tools` installed

If you have installed `sudo apt install ros-dev-tools` before, remove it with `sudo apt purge ros-dev-tools`.

```console
mfc@whale:~$ apt show ros-dev-tools
Depends: ros-build-essential, python3-bloom, python3-colcon-common-extensions, python3-colcon-mixin, python3-rosdep, python3-vcstool, wget
```

Then install:
`sudo apt install ros-build-essential python3-bloom python3-colcon-common-extensions python3-colcon-mixin python3-rosdep python3-vcs2l wget` in its place.


### If you have only `python3-vcstool` installed

If you have installed `sudo apt install python3-vcstool` before, remove it with  `sudo apt purge  python3-vcstool`. And just install `sudo apt install python3-vcs2l`.

If you have the following line in your .bashrc, replace it:
- from: `source /usr/share/vcstool-completion/vcs.bash`
- to:      `source /usr/share/vcs2l-completion/vcs.bash`

## How was this PR tested?

CI.