### PR TITLE
feat: install nanoflann by ansible

### DIFF
--- a/ansible/roles/dev_tools/tasks/main.yaml
+++ b/ansible/roles/dev_tools/tasks/main.yaml
@@ -62,3 +62,11 @@
   ansible.builtin.debug:
     msg: ROS package 'ros-{{ rosdistro }}-plotjuggler' is apt-mark hold. Skipping installation.
   when: not dev_tools__install_result.changed
+
+- name: Install nanoflann
+  become: true
+  ansible.builtin.apt:
+    name: 
+      - libnanoflann-dev
+    state: present
+    update_cache: true

--- a/ansible/roles/dev_tools/tasks/main.yaml
+++ b/ansible/roles/dev_tools/tasks/main.yaml
@@ -66,7 +66,7 @@
 - name: Install nanoflann
   become: true
   ansible.builtin.apt:
-    name: 
+    name:
       - libnanoflann-dev
     state: present
     update_cache: true


### PR DESCRIPTION
## Description
- Use ansible to install the library nanoflann, which accelerate the radius search by Kdtree


**Related PR:**
- https://github.com/autowarefoundation/autoware_core/pull/764
- Older PR: https://github.com/autowarefoundation/autoware_universe/pull/10013

## How was this PR tested?
- Re-run `./setup-dev-env.sh` to install libnanoflann-dev
- Run `dpkg -l | grep nanoflann `to confirm whether the libnanoflann-dev is installed
