### PR TITLE
feat(ansible): install libnpp and libnvjpeg from cuda role

### DIFF
--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -36,6 +36,8 @@
       - libcurand-dev-{{ cuda__dash_case_cuda_version.stdout }}
       - cuda-nvml-dev-{{ cuda__dash_case_cuda_version.stdout }}
       - cuda-nvrtc-dev-{{ cuda__dash_case_cuda_version.stdout }}
+      - libnpp-dev-{{ cuda__dash_case_cuda_version.stdout }}
+      - libnvjpeg-dev-{{ cuda__dash_case_cuda_version.stdout }}
     update_cache: true
   when: install_devel == 'y'
 
@@ -47,6 +49,8 @@
       - libcusparse-{{ cuda__dash_case_cuda_version.stdout }}
       - libcublas-{{ cuda__dash_case_cuda_version.stdout }}
       - libcurand-{{ cuda__dash_case_cuda_version.stdout }}
+      - libnpp-{{ cuda__dash_case_cuda_version.stdout }}
+      - libnvjpeg-{{ cuda__dash_case_cuda_version.stdout }}
     update_cache: true
   when: install_devel == 'N'
 

--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -1,3 +1,4 @@
+# cspell:ignore libnvjpeg
 - name: Get CUDA architecture name
   ansible.builtin.shell: |
     if [ "$(uname -m)" = "x86_64" ]; then


### PR DESCRIPTION
## Description

* https://github.com/tier4/accelerated_image_processor
* https://github.com/tier4/ros2_v4l2_camera

Some of the cuda-heavy packages stated above require libnpp and libnvjpeg to build, and I find this role efficient to do all setups if we don't need finer-grain control.

## How was this PR tested?

[Evaluator (TIER IV internal, after applying equivalent patch: build passes)](https://evaluation.tier4.jp/evaluation/reports/44dcbcf1-f7fd-537e-9c3a-4061088322b5/builds/80b64277-945d-5ee1-9639-e7bf6b669657?project_id=x2_dev)
[Evaluator (TIER IV internal, before applying equivalent patch: build fails)](https://evaluation.tier4.jp/evaluation/reports/d93dead2-6cdc-508e-9a77-6cac94d9ef9e/builds/f3d7fecd-8ae5-5e39-b129-c120f87c9c46?project_id=x2_dev)
[The equivalent patch (TIER IV internal)](https://github.com/tier4/pilot-auto.x2/commit/352761e61672e9460dc4a6362c5eb81f91cc0e63)