### PR TITLE
build(tools*.repos): remove plot-juggler-plugins repo dep

### DIFF
--- a/tools-nightly.repos
+++ b/tools-nightly.repos
@@ -3,8 +3,3 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_tools.git
     version: main
-  # This should be removed after merged PR (https://github.com/PlotJuggler/plotjuggler-ros-plugins/pull/94)
-  plotjuggler_ros:
-    type: git
-    url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
-    version: 2.1.2-humble

--- a/tools.repos
+++ b/tools.repos
@@ -3,8 +3,3 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_tools.git
     version: 0.4.0
-  # This should be removed after merged PR (https://github.com/PlotJuggler/plotjuggler-ros-plugins/pull/94)
-  plotjuggler_ros:
-    type: git
-    url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
-    version: 2.1.2-humble


### PR DESCRIPTION
## Description

We can remove this since it comes with humble.

- https://github.com/autowarefoundation/autoware/pull/6203 has introduced it.

## How was this PR tested?

I've confirmed **entire autoware** with autoware-nightly, tools, simulator **compiles without it**, when you do rosdep install.