### PR TITLE
fix(ansible): add become:true to be root user when downloading gpg key

### DIFF
--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -54,6 +54,7 @@
     url: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xCFDB1950382092423DF37D3E075CD8B5C91E5ACA
     dest: /tmp/agnocast-ppa.asc
     mode: "0644"
+  become: true
   register: agnocast_gpg_key_download
 
 - name: Convert GPG key to binary format and install

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -65,6 +65,12 @@
     creates: /etc/apt/keyrings/agnocast-ppa.gpg
   become: true
 
+- name: Remove temporary GPG key file
+  ansible.builtin.file:
+    path: /tmp/agnocast-ppa.asc
+    state: absent
+  become: true
+
 - name: Verify GPG key fingerprint
   ansible.builtin.shell: |
     set -o pipefail


### PR DESCRIPTION
## Description
Fix permission error when downloading agnocast PPA GPG key.
  
### Changes
- Remove `/tmp/agnocast-ppa.asc` before downloading to ensure a clean state
- Add `become: true` to handle environments where the file already exists with root ownership
  
### Problem
The task fails when `/tmp/agnocast-ppa.asc` already exists with root ownership:
```
"msg": "Destination /tmp/agnocast-ppa.asc is not writable"
```
 
### Solution
Delete the temporary file before each download to avoid conflicts. The `become: true` ensures backward compatibility with environments that already have the root-owned file.

## How was this PR tested?
I've checked that the following task successfully completed even when root user is the owner of `/tmp/agnocast-ppa.asc`.

```
TASK [autoware.dev_env.agnocast : Download agnocast PPA GPG key while IPv6 is disabled] *************************************************************************************************************************************************************************************************************************************************************************************************************************************************
changed: [localhost]

TASK [autoware.dev_env.agnocast : Convert GPG key to binary format and install] *********************************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [autoware.dev_env.agnocast : Remove temporary GPG key file] ************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
changed: [localhost]
```
