### PR TITLE
fix: path to repos files for bump-repo-versions-* workflow

### DIFF
--- a/.github/workflows/bump-repo-versions-autoware.yaml
+++ b/.github/workflows/bump-repo-versions-autoware.yaml
@@ -31,5 +31,5 @@ jobs:
           targets: major minor patch
           base_branch: main
           new_branch_prefix: feat/update-
-          autoware_repos_file_name: autoware.repos
+          autoware_repos_file_name: repositories/autoware.repos
           verbosity: 0

--- a/.github/workflows/bump-repo-versions-simulator.yaml
+++ b/.github/workflows/bump-repo-versions-simulator.yaml
@@ -31,5 +31,5 @@ jobs:
           targets: major minor
           base_branch: main
           new_branch_prefix: feat/update-
-          autoware_repos_file_name: simulator.repos
+          autoware_repos_file_name: repositories/simulator.repos
           verbosity: 0

--- a/.github/workflows/bump-repo-versions-tools.yaml
+++ b/.github/workflows/bump-repo-versions-tools.yaml
@@ -31,5 +31,5 @@ jobs:
           targets: major minor patch
           base_branch: main
           new_branch_prefix: feat/update-
-          autoware_repos_file_name: tools.repos
+          autoware_repos_file_name: repositories/tools.repos
           verbosity: 0


### PR DESCRIPTION
## Description
This is a follow up PR from https://github.com/autowarefoundation/autoware/pull/6646

## How was this PR tested?
