### PR TITLE
fix(docker): add tigervnc-tools to visualizer dependencies

### DIFF
--- a/docker/tools/visualizer/Dockerfile
+++ b/docker/tools/visualizer/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   openbox \
   tigervnc-standalone-server \
   tigervnc-common \
+  tigervnc-tools \
   novnc \
   websockify \
   python3-numpy \


### PR DESCRIPTION
## Description

This PR fixes the error:

`vncserver: Couldn't find "tigervncpasswd" on your PATH.`

Also mentioned on https://github.com/autowarefoundation/autoware/issues/6665

## How was this PR tested?
