### PR TITLE
docs(ansible): fix typo

### DIFF
--- a/ansible/roles/spconv/README.md
+++ b/ansible/roles/spconv/README.md
@@ -1,7 +1,7 @@
 # spconv
 
 This role install the `cumm` and `spconv` libraries needed to perform sparse convolutions.
-The [original implementation](https://github.com/traveller59/spconv) did not provide a shared library, which is pre-generated c++ code and pre-compiled libraries were prepared [separatedly](https://github.com/autowarefoundation/spconv_cpp).
+The [original implementation](https://github.com/traveller59/spconv) did not provide a shared library, which is pre-generated c++ code and pre-compiled libraries were prepared [separately](https://github.com/autowarefoundation/spconv_cpp).
 
 ## Manual Installation
 


### PR DESCRIPTION
## Description

Fixes small typos in ansible spconv README

## How was this PR tested?

-