### PR TITLE
docs(ansible): update cuda and driver instructions

### DIFF
--- a/ansible/roles/cuda/README.md
+++ b/ansible/roles/cuda/README.md
@@ -15,7 +15,9 @@ This role also registers Vulkan, OpenGL, and OpenCL GPU vendors for future use.
 
 ### Version compatibility
 
-Autoware currently uses CUDA `12.4` which corresponds to the NVIDIA driver version `550` and is minimum required driver version.
+- Autoware requires **CUDA 12.4** at minimum, which corresponds to **NVIDIA driver version 550**.
+- Autoware is fully compatible with the newer CUDA release: **CUDA 12.8**.
+- Autoware runs reliably with the **latest NVIDIA GPU drivers**.
 
 #### 🛠️ For Advanced Users
 
@@ -50,7 +52,15 @@ sudo dpkg -i cuda-keyring_1.1-1_all.deb
 sudo apt-get update
 cuda_version_dashed=$(eval sed -e "s/[.]/-/g" <<< "${cuda_version}")
 sudo apt-get -y install cuda-toolkit-${cuda_version_dashed}
+```
+
+```bash
+# ⚠️ this is the minimum version
 sudo apt-get install -y cuda-drivers-550
+
+# ✅ latest version is OK
+apt search '^nvidia-driver-[0-9]+'
+sudo apt install nvidia-driver-580  # or whichever is latest
 ```
 
 Perform the post installation actions:


### PR DESCRIPTION
## Description

To reduce confusion and give most up to date instructions.

## How was this PR tested?

```console
mfc@whale:~$ nvcc -V
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2025 NVIDIA Corporation
Built on Fri_Feb_21_20:23:50_PST_2025
Cuda compilation tools, release 12.8, V12.8.93
Build cuda_12.8.r12.8/compiler.35583870_0
```

I've been using this CUDA version (`12.8`) for the longest time without issues with autoware.
Also CI uses `CUDA 12.4`.
So I added it as a suggestion for the users.

Also some users had issue with old nvidia drivers so I updated the instructions to recommend the latest nvidia drivers.

I also have `nvidia-driver-580` on my machine and added that but also shared how to find the latest drivers in the instructions too.