### PR TITLE
chore: upgrade to CUDA 12.8

### DIFF
--- a/amd64.env
+++ b/amd64.env
@@ -7,7 +7,7 @@ base_image=ros:humble-ros-base-jammy
 autoware_base_image=ghcr.io/autowarefoundation/autoware-base:latest
 autoware_base_cuda_image=ghcr.io/autowarefoundation/autoware-base:cuda-latest
 
-cuda_version=12.4
+cuda_version=12.8
 cudnn_version=8.9.7.29-1+cuda12.2
 tensorrt_version=10.8.0.43-1+cuda12.8
 pre_commit_clang_format_version=17.0.5

--- a/ansible/roles/cuda/README.md
+++ b/ansible/roles/cuda/README.md
@@ -50,7 +50,12 @@ sudo dpkg -i cuda-keyring_1.1-1_all.deb
 sudo apt-get update
 cuda_version_dashed=$(eval sed -e "s/[.]/-/g" <<< "${cuda_version}")
 sudo apt-get -y install cuda-toolkit-${cuda_version_dashed}
+# ⚠️ this is the minimum version
 sudo apt-get install -y cuda-drivers-570
+
+# ✅ latest version is OK
+apt search '^nvidia-driver-[0-9]+'
+sudo apt install nvidia-driver-580  # or whichever is latest
 ```
 
 Perform the post installation actions:

--- a/ansible/roles/cuda/README.md
+++ b/ansible/roles/cuda/README.md
@@ -1,6 +1,6 @@
 # cuda
 
-This role installs [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit) following [this page](https://developer.nvidia.com/cuda-12-4-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=22.04&target_type=deb_network) and [this page](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#post-installation-actions).
+This role installs [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit) following [this page](https://developer.nvidia.com/cuda-12-8-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=22.04&target_type=deb_network) and [this page](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#post-installation-actions).
 
 This role also registers Vulkan, OpenGL, and OpenCL GPU vendors for future use.
 
@@ -15,9 +15,7 @@ This role also registers Vulkan, OpenGL, and OpenCL GPU vendors for future use.
 
 ### Version compatibility
 
-- Autoware requires **CUDA 12.4** at minimum, which corresponds to **NVIDIA driver version 550**.
-- Autoware is fully compatible with the newer CUDA release: **CUDA 12.8**.
-- Autoware runs reliably with the **latest NVIDIA GPU drivers**.
+Autoware currently uses CUDA `12.8` which corresponds to the NVIDIA driver version `570` and is minimum required driver version.
 
 #### 🛠️ For Advanced Users
 
@@ -52,15 +50,7 @@ sudo dpkg -i cuda-keyring_1.1-1_all.deb
 sudo apt-get update
 cuda_version_dashed=$(eval sed -e "s/[.]/-/g" <<< "${cuda_version}")
 sudo apt-get -y install cuda-toolkit-${cuda_version_dashed}
-```
-
-```bash
-# ⚠️ this is the minimum version
-sudo apt-get install -y cuda-drivers-550
-
-# ✅ latest version is OK
-apt search '^nvidia-driver-[0-9]+'
-sudo apt install nvidia-driver-580  # or whichever is latest
+sudo apt-get install -y cuda-drivers-570
 ```
 
 Perform the post installation actions:

--- a/ansible/roles/cuda/README.md
+++ b/ansible/roles/cuda/README.md
@@ -15,7 +15,8 @@ This role also registers Vulkan, OpenGL, and OpenCL GPU vendors for future use.
 
 ### Version compatibility
 
-Autoware currently uses CUDA `12.8` which corresponds to the NVIDIA driver version `570` and is minimum required driver version.
+- CUDA version `12.8`.
+- NVIDIA driver version `570` or **newer**.
 
 #### 🛠️ For Advanced Users
 

--- a/ansible/roles/cuda/README.md
+++ b/ansible/roles/cuda/README.md
@@ -51,6 +51,9 @@ sudo dpkg -i cuda-keyring_1.1-1_all.deb
 sudo apt-get update
 cuda_version_dashed=$(eval sed -e "s/[.]/-/g" <<< "${cuda_version}")
 sudo apt-get -y install cuda-toolkit-${cuda_version_dashed}
+```
+
+```bash
 # ⚠️ this is the minimum version
 sudo apt-get install -y cuda-drivers-570
 

--- a/ansible/roles/spconv/tasks/main.yaml
+++ b/ansible/roles/spconv/tasks/main.yaml
@@ -6,7 +6,7 @@
 - name: Download the cumm package
   ansible.builtin.get_url:
     mode: "0644"
-    url: https://github.com/autowarefoundation/spconv_cpp/releases/download/spconv_v{{ spconv_version }}%2Bcumm_v{{ cumm_version }}/cumm_{{ cumm_version }}_{{ spconv_normalized_arch }}.deb
+    url: https://github.com/autowarefoundation/spconv_cpp/releases/download/spconv_v{{ spconv_version }}%2Bcumm_v{{ cumm_version }}%2Bcu128/cumm_{{ cumm_version }}_{{ spconv_normalized_arch }}.deb
     dest: /tmp/cumm.deb
 
 - name: Install the cumm package
@@ -18,7 +18,7 @@
 - name: Download the spconv package
   ansible.builtin.get_url:
     mode: "0644"
-    url: https://github.com/autowarefoundation/spconv_cpp/releases/download/spconv_v{{ spconv_version }}%2Bcumm_v{{ cumm_version }}/spconv_{{ spconv_version }}_{{ spconv_normalized_arch }}.deb
+    url: https://github.com/autowarefoundation/spconv_cpp/releases/download/spconv_v{{ spconv_version }}%2Bcumm_v{{ cumm_version }}%2Bcu128/spconv_{{ spconv_version }}_{{ spconv_normalized_arch }}.deb
     dest: /tmp/spconv.deb
 
 - name: Install the spconv package


### PR DESCRIPTION
## Description

Latest Blackwell GPUs requires CUDA 12.8+. This PR upgrades CUDA to 12.8 alongside with driver requirements to 570+.

Spconv library is already deployed with [cu128](https://github.com/autowarefoundation/spconv_cpp/releases/tag/spconv_v2.3.8%2Bcumm_v0.5.3%2Bcu128).

After PR merge, I will address relevant PRs in autoware_universe in terms of full Blackwell compatibility.

Note: Check if Autoware CUDA base image has been rebuild **before** Autoware image build start. Otherwise Autoware image inherit from deprecated Autoware CUDA base image.

## How was this PR tested?

Local build with `RTX PRO 6000 Blackwell`.