### PR TITLE
chore: upgrade to CUDA 12.8 for jazzy

### DIFF
--- a/amd64_jazzy.env
+++ b/amd64_jazzy.env
@@ -7,7 +7,7 @@ base_image=ros:jazzy-ros-base-noble
 autoware_base_image=ghcr.io/autowarefoundation/autoware-base:latest-jazzy
 autoware_base_cuda_image=ghcr.io/autowarefoundation/autoware-base:jazzy-cuda-latest
 
-cuda_version=12.4
+cuda_version=12.8
 cudnn_version=8.9.7.29-1+cuda12.2
 tensorrt_version=10.8.0.43-1+cuda12.8
 pre_commit_clang_format_version=17.0.5


### PR DESCRIPTION
## Description

Related to https://github.com/autowarefoundation/autoware/pull/6714
I didn't notice the new env file for jazzy distro.

## How was this PR tested?
