### PR TITLE
fix(ansible): spconv installation for sbsa/jetson

### DIFF
--- a/ansible/roles/spconv/README.md
+++ b/ansible/roles/spconv/README.md
@@ -3,6 +3,15 @@
 This role install the `cumm` and `spconv` libraries needed to perform sparse convolutions.
 The [original implementation](https://github.com/traveller59/spconv) did not provide a shared library, which is pre-generated c++ code and pre-compiled libraries were prepared [separately](https://github.com/autowarefoundation/spconv_cpp).
 
+## Architecture Support
+
+This role supports different architectures with platform-specific package variants:
+
+- **amd64**: No suffix (e.g., `cumm_0.5.3_amd64.deb`)
+- **arm64**:
+  - Default: `-sbsa` suffix for server platforms (e.g., `cumm_0.5.3_arm64-sbsa.deb`)
+  - Jetson: `-jetson` suffix when `spconv_is_jetson=true` (e.g., `cumm_0.5.3_arm64-jetson.deb`)
+
 ## Manual Installation
 
 For manual installation, please follow the instructions in [this](https://github.com/autowarefoundation/spconv_cpp) repository.
@@ -11,8 +20,18 @@ For manual installation, please follow the instructions in [this](https://github
 
 The following command will install a particular version of the packages using ansible.
 
+### Standard installation (amd64 or arm64 server)
+
 ```bash
 export CUMM_VERSION=0.5.3
 export SPCONV_VERSION=2.3.8
 ansible-playbook autoware.dev_env.install_spconv.yaml -e cumm_version=${CUMM_VERSION} -e spconv_version=${SPCONV_VERSION} --ask-become-pass
+```
+
+### Installation for NVIDIA Jetson platforms
+
+```bash
+export CUMM_VERSION=0.5.3
+export SPCONV_VERSION=2.3.8
+ansible-playbook autoware.dev_env.install_spconv.yaml -e cumm_version=${CUMM_VERSION} -e spconv_version=${SPCONV_VERSION} -e spconv_is_jetson=true --ask-become-pass
 ```

--- a/ansible/roles/spconv/defaults/main.yaml
+++ b/ansible/roles/spconv/defaults/main.yaml
@@ -1,0 +1,1 @@
+spconv_is_jetson: false

--- a/ansible/roles/spconv/tasks/main.yaml
+++ b/ansible/roles/spconv/tasks/main.yaml
@@ -3,10 +3,14 @@
   ansible.builtin.set_fact:
     spconv_normalized_arch: "{{ ansible_architecture | regex_replace('aarch64', 'arm64') | regex_replace('x86_64', 'amd64') }}"
 
+- name: Set architecture suffix
+  ansible.builtin.set_fact:
+    spconv_arch_suffix: "{{ '-jetson' if (spconv_normalized_arch == 'arm64' and spconv_is_jetson | bool) else ('-sbsa' if spconv_normalized_arch == 'arm64' else '') }}"
+
 - name: Download the cumm package
   ansible.builtin.get_url:
     mode: "0644"
-    url: https://github.com/autowarefoundation/spconv_cpp/releases/download/spconv_v{{ spconv_version }}%2Bcumm_v{{ cumm_version }}%2Bcu128/cumm_{{ cumm_version }}_{{ spconv_normalized_arch }}.deb
+    url: https://github.com/autowarefoundation/spconv_cpp/releases/download/spconv_v{{ spconv_version }}%2Bcumm_v{{ cumm_version }}%2Bcu128/cumm_{{ cumm_version }}_{{ spconv_normalized_arch }}{{ spconv_arch_suffix }}.deb
     dest: /tmp/cumm.deb
 
 - name: Install the cumm package
@@ -18,7 +22,7 @@
 - name: Download the spconv package
   ansible.builtin.get_url:
     mode: "0644"
-    url: https://github.com/autowarefoundation/spconv_cpp/releases/download/spconv_v{{ spconv_version }}%2Bcumm_v{{ cumm_version }}%2Bcu128/spconv_{{ spconv_version }}_{{ spconv_normalized_arch }}.deb
+    url: https://github.com/autowarefoundation/spconv_cpp/releases/download/spconv_v{{ spconv_version }}%2Bcumm_v{{ cumm_version }}%2Bcu128/spconv_{{ spconv_version }}_{{ spconv_normalized_arch }}{{ spconv_arch_suffix }}.deb
     dest: /tmp/spconv.deb
 
 - name: Install the spconv package


### PR DESCRIPTION
## Description

CUDA image for `arm64` fails. This is because latest spconv deployment for `cu128` considers `jetson`/`sbsa` target platforms defined explicitly. This PR make sure that correct link in CI/CD is used. Also documentation explains how to manually install spconv for Jetson.

Note: If Jetson Orin support dropped, we can focus only on Thor platforms, where `sbsa` binaries are compliant and therefore this separation can be removed.

## How was this PR tested?
