### PR TITLE
feat(docker-build-and-push-cuda): use self hosted ARM64

### DIFF
--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -166,7 +166,7 @@ jobs:
             arch-platform: linux/amd64
             lib-dir: x86_64
           - platform: arm64
-            runner: ubuntu-22.04-arm
+            runner: [self-hosted, Linux, ARM64]
             arch-platform: linux/arm64
             lib-dir: aarch64
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
## Description

This PR switches `docker-build-and-push-cuda` to use self hosted ARM machine.

https://github.com/autowarefoundation/autoware/actions/runs/20986800073/job/60340788605 was failing due to lack of disk space after we switched to `CUDA 12.8`:
- https://github.com/autowarefoundation/autoware/pull/6714
- https://github.com/autowarefoundation/autoware/pull/6715

@mitsudome-r :

> It seems like the latest docker-build-and-push-cuda (arm64) only had 1.8G left when we successfully finished the workflow. Maybe updating to CUDA 12.8 used up the remaining space.
> https://github.com/autowarefoundation/autoware/actions/runs/20851656038/job/59926902763
> 
> <img width="1830" height="918" alt="image" src="https://github.com/user-attachments/assets/8e91d0cb-ffe3-4f2a-8ef6-0cdf1c24f8d6" />

@amadeuszsz :

> Yeah, overall it took about 2 GB I guess, when I compared image size after local build.
> I think we can remove cudnn from autoware and it will save 2GB~. Current version of TensorRT does not need cudnn anymore, only few deprecated layers needs cudnn, which we don't use at all. Therefore I will remove cudnn from cmakelists & package.xml and test the runtime. Multiple packages includes cudnn but not use it at all.
> If this will work, we can ask bevformer & bevdet maintainers to refactor their code as they use cudnn unfortunately.
> I will back to you later if cudnn removal  from tier4-maintained packages will be possible.

## How was this PR tested?

Testing here: https://github.com/autowarefoundation/autoware/actions/runs/21025141791 ❌ failed due to some cache issue. Probably because I ran it from workflow dispatch.
