### PR TITLE
chore: remove cudnn dependency

### DIFF
--- a/amd64.env
+++ b/amd64.env
@@ -8,7 +8,6 @@ autoware_base_image=ghcr.io/autowarefoundation/autoware-base:latest
 autoware_base_cuda_image=ghcr.io/autowarefoundation/autoware-base:cuda-latest
 
 cuda_version=12.8
-cudnn_version=8.9.7.29-1+cuda12.2
 tensorrt_version=10.8.0.43-1+cuda12.8
 pre_commit_clang_format_version=17.0.5
 cumm_version=0.5.3

--- a/amd64_jazzy.env
+++ b/amd64_jazzy.env
@@ -8,7 +8,6 @@ autoware_base_image=ghcr.io/autowarefoundation/autoware-base:latest-jazzy
 autoware_base_cuda_image=ghcr.io/autowarefoundation/autoware-base:jazzy-cuda-latest
 
 cuda_version=12.8
-cudnn_version=8.9.7.29-1+cuda12.2
 tensorrt_version=10.8.0.43-1+cuda12.8
 pre_commit_clang_format_version=17.0.5
 cumm_version=0.5.3

--- a/ansible/playbooks/docker.yaml
+++ b/ansible/playbooks/docker.yaml
@@ -4,7 +4,7 @@
   vars_prompt:
     - name: prompt_install_nvidia
       prompt: |-
-        [Warning] Some Autoware components depend on the CUDA, cuDNN and TensorRT NVIDIA libraries which have end-user license agreements that should be reviewed before installation.
+        [Warning] Some Autoware components depend on the CUDA, and TensorRT NVIDIA libraries which have end-user license agreements that should be reviewed before installation.
         Install NVIDIA libraries? [y/N]
       private: false
   pre_tasks:
@@ -12,7 +12,6 @@
       ansible.builtin.debug:
         msg:
           - cuda_version: "{{ cuda_version }}"
-          - cudnn_version: "{{ cudnn_version }}"
     - name: Show a warning if the NVIDIA libraries will not be installed
       ansible.builtin.pause:
         seconds: 10

--- a/ansible/playbooks/openadkit.yaml
+++ b/ansible/playbooks/openadkit.yaml
@@ -14,7 +14,6 @@
           - rosdistro: "{{ rosdistro }}"
           - rmw_implementation: "{{ rmw_implementation }}"
           - cuda_version: "{{ cuda_version }}"
-          - cudnn_version: "{{ cudnn_version }}"
           - tensorrt_version: "{{ tensorrt_version }}"
   roles:
     # Autoware base dependencies

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -4,7 +4,7 @@
   vars_prompt:
     - name: prompt_install_nvidia
       prompt: |-
-        [Warning] Some Autoware components depend on the CUDA, cuDNN and TensorRT NVIDIA libraries which have end-user license agreements that should be reviewed before installation.
+        [Warning] Some Autoware components depend on the CUDA, and TensorRT NVIDIA libraries which have end-user license agreements that should be reviewed before installation.
         Install NVIDIA libraries? [y/N]
       private: false
     - name: prompt_download_artifacts
@@ -29,7 +29,6 @@
           - rosdistro: "{{ rosdistro }}"
           - rmw_implementation: "{{ rmw_implementation }}"
           - cuda_version: "{{ cuda_version }}"
-          - cudnn_version: "{{ cudnn_version }}"
           - tensorrt_version: "{{ tensorrt_version }}"
 
     - name: Show a warning if the NVIDIA libraries will not be installed

--- a/ansible/roles/tensorrt/README.md
+++ b/ansible/roles/tensorrt/README.md
@@ -1,12 +1,11 @@
 # tensorrt
 
-This role installs TensorRT and cuDNN following [the official NVIDIA TensorRT Installation Guide](https://docs.nvidia.com/deeplearning/tensorrt/install-guide/index.html#installing).
+This role installs TensorRT following [the official NVIDIA TensorRT Installation Guide](https://docs.nvidia.com/deeplearning/tensorrt/install-guide/index.html#installing).
 
 ## Inputs
 
 | Name             | Required | Description              |
 | ---------------- | -------- | ------------------------ |
-| cudnn_version    | true     | The version of cuDNN.    |
 | tensorrt_version | true     | The version of TensorRT. |
 
 ## Manual Installation
@@ -16,11 +15,9 @@ This role installs TensorRT and cuDNN following [the official NVIDIA TensorRT In
 wget -O /tmp/amd64.env https://raw.githubusercontent.com/autowarefoundation/autoware/main/amd64.env && source /tmp/amd64.env
 
 sudo apt-get install -y \
-libcudnn8=${cudnn_version} \
 libnvinfer10=${tensorrt_version} \
 libnvinfer-plugin10=${tensorrt_version} \
 libnvonnxparsers10=${tensorrt_version} \
-libcudnn8-dev=${cudnn_version} \
 libnvinfer-dev=${tensorrt_version} \
 libnvinfer-plugin-dev=${tensorrt_version} \
 libnvinfer-headers-dev=${tensorrt_version} \
@@ -28,11 +25,9 @@ libnvinfer-headers-plugin-dev=${tensorrt_version} \
 libnvonnxparsers-dev=${tensorrt_version}
 
 sudo apt-mark hold \
-libcudnn8 \
 libnvinfer10 \
 libnvinfer-plugin10 \
 libnvonnxparsers10 \
-libcudnn8-dev \
 libnvinfer-dev \
 libnvinfer-plugin-dev \
 libnvonnxparsers-dev \

--- a/ansible/roles/tensorrt/tasks/main.yaml
+++ b/ansible/roles/tensorrt/tasks/main.yaml
@@ -1,8 +1,7 @@
-- name: Install cuDNN and TensorRT
+- name: Install TensorRT
   become: true
   ansible.builtin.apt:
     name:
-      - libcudnn8={{ cudnn_version }}
       - libnvinfer10={{ tensorrt_version }}
       - libnvinfer-plugin10={{ tensorrt_version }}
       - libnvonnxparsers10={{ tensorrt_version }}
@@ -10,11 +9,10 @@
     allow_downgrade: true
     update_cache: true
 
-- name: Install cuDNN and TensorRT Dev
+- name: Install TensorRT Dev
   become: true
   ansible.builtin.apt:
     name:
-      - libcudnn8-dev={{ cudnn_version }}
       - libnvinfer-dev={{ tensorrt_version }}
       - libnvinfer-plugin-dev={{ tensorrt_version }}
       - libnvinfer-headers-dev={{ tensorrt_version }}
@@ -32,7 +30,6 @@
     name: "{{ item }}"
     selection: hold
   with_items:
-    - libcudnn8
     - libnvinfer10
     - libnvinfer-plugin10
     - libnvonnxparsers10
@@ -43,7 +40,6 @@
     name: "{{ item }}"
     selection: hold
   with_items:
-    - libcudnn8-dev
     - libnvinfer-dev
     - libnvinfer-plugin-dev
     - libnvinfer-headers-dev


### PR DESCRIPTION
## Description

Remove CUDNN as it is unused dependency.

Saves about 2.1~ GB.

Note 1: All packages' PRs have to be merged first.
Note 2: `trt_batched_nms` need hash update in repos file after merge in upstream.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/6729#issuecomment-3757777221

## How was this PR tested?
