### PR TITLE
feat(autoware.repos): bump trt_batched_nms to 0.1.0

### DIFF
--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -81,7 +81,7 @@ repositories:
   universe/external/trt_batched_nms:
     type: git
     url: https://github.com/autowarefoundation/trt_batched_nms.git
-    version: 1a9df130b4a5d96c25019b5793abbfde42d237ac
+    version: 0.1.0
   universe/external/cuda_blackboard:
     type: git
     url: https://github.com/autowarefoundation/cuda_blackboard.git


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware/issues/6729
- Related: https://github.com/autowarefoundation/autoware/pull/6730
- Changes: https://github.com/autowarefoundation/trt_batched_nms/commit/98024a240c6329704ef03fd7ef10011dddb5da67
- Release: https://github.com/autowarefoundation/trt_batched_nms/releases/tag/0.1.0

## How was this PR tested?

