### PR TITLE
feat(autoware.repos): bump bevdet_vendor to 0.1.0

### DIFF
--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -77,7 +77,7 @@ repositories:
   universe/external/bevdet_vendor: # TODO: wrap the original bevdet-tensorrt-cpp source code as a vendor package and provide it to autoware_tensorrt_bevdet package
     type: git
     url: https://github.com/autowarefoundation/bevdet_vendor.git
-    version: bevdet_vendor-ros2
+    version: 0.1.0
   universe/external/trt_batched_nms:
     type: git
     url: https://github.com/autowarefoundation/trt_batched_nms.git


### PR DESCRIPTION
## Description

This was pointing to a branch.

Today I made a release in the main branch and now it is pointing to the release tag.

https://github.com/autowarefoundation/bevdet_vendor/releases/tag/0.1.0

## How was this PR tested?
