### PR TITLE
chore(autoware.repos): bump cuda_blackboard to 0.3.0

### DIFF
--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -85,7 +85,7 @@ repositories:
   universe/external/cuda_blackboard:
     type: git
     url: https://github.com/autowarefoundation/cuda_blackboard.git
-    version: v0.2.0
+    version: 0.3.0
   universe/external/negotiated:
     type: git
     url: https://github.com/osrf/negotiated.git


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/cuda_blackboard/compare/v0.2.0...0.3.0

Updated the releases and tags to remove the preceding `v` letter.
(Kept the older tags duplicated with `v` to keep compatibility)

https://github.com/autowarefoundation/cuda_blackboard/tags

## How was this PR tested?

Only missing includes are added from last release, rest are linter fixes.