### PR TITLE
build: make ansible version consistent in repository

### DIFF
--- a/.webauto-ci/main/environment-setup/run.sh
+++ b/.webauto-ci/main/environment-setup/run.sh
@@ -5,7 +5,7 @@ apt-get update
 apt-get -y install sudo curl wget unzip gnupg lsb-release ccache python3-apt python3-pip apt-utils software-properties-common jq
 add-apt-repository universe
 
-pip install --no-cache-dir 'ansible==6.*'
+pip install --no-cache-dir 'ansible==10.*'
 
 user=autoware
 useradd -m "$user" -s /bin/bash

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -18,7 +18,7 @@ sudo apt-get -y install pipx
 python3 -m pipx ensurepath
 
 # Install ansible
-pipx install --include-deps --force "ansible==6.*"
+pipx install --include-deps --force "ansible==10.*"
 ```
 
 ### Install ansible collections


### PR DESCRIPTION
## Summary

- Related: https://github.com/autowarefoundation/autoware/issues/6695

This PR updates the Ansible version used in CI and documented local setup from `6.*` to `10.*`, making them consistent with the existing development environment setup script.

Existing tooling:
https://github.com/autowarefoundation/autoware/blob/723b97aab4c1ba68280b36f6eab1dc2685e383e4/setup-dev-env.sh#L205

## Key Changes

* **CI environment setup**

  * Updated `.webauto-ci/main/environment-setup/run.sh` to install `ansible==10.*`.

* **Developer documentation**

  * Updated `ansible/README.md` to install `ansible==10.*` via `pipx`.

## Motivation

The repository already installs Ansible `10.*` in `setup-dev-env.sh`, but CI and the Ansible README were still pinned to `6.*`. This PR aligns all Ansible installation paths to the same version to avoid confusion and environment drift.

> This makes CI, documented manual setup, and the dev environment script consistent.

## Testing

* No changes to Ansible playbooks or roles.
* CI setup updated to match the existing dev environment configuration.
* No expected behavioral changes beyond version alignment.

## Notes for Reviewers

* This is a consistency fix rather than a functional change.
* Ansible `10.*` is already in use via `setup-dev-env.sh`.
* Any issues would likely surface as version-related warnings in CI.