### PR TITLE
build(ansible): install gdown via pipx

### DIFF
--- a/ansible/roles/gdown/README.md
+++ b/ansible/roles/gdown/README.md
@@ -9,6 +9,5 @@ None.
 ## Manual Installation
 
 ```bash
-# Install gdown to download files from CMakeLists.txt
-pip3 install gdown
+pipx install gdown
 ```

--- a/ansible/roles/gdown/tasks/main.yaml
+++ b/ansible/roles/gdown/tasks/main.yaml
@@ -1,17 +1,4 @@
-# noqa: risky-shell-pipe, no-changed-when
-
 - name: Install gdown to download files from CMakeLists.txt
-  ansible.builtin.shell: |
-    set -o pipefail
-    pip3 list | grep -q gdown || pip3 install --break-system-packages gdown
-  args:
-    executable: /bin/bash
-  when: rosdistro == 'jazzy'
-
-- name: Install gdown to download files from CMakeLists.txt (non-jazzy)
-  ansible.builtin.pip:
-    name:
-      - gdown
-    state: latest
-    executable: pip3
-  when: rosdistro != 'jazzy'
+  community.general.pipx:
+    name: gdown
+    executable: /usr/bin/pipx


### PR DESCRIPTION
## Summary

- Related: https://github.com/autowarefoundation/autoware/issues/6695

This PR standardizes the installation of `gdown` by switching from `pip`/`pip3` to `pipx` across the Ansible role and documentation.

## Key Changes

* **Unified gdown installation**

  * Replaced conditional `pip`/`pip3` logic with `community.general.pipx`.
  * Removed ROS distro–specific handling.

* **Documentation update**

  * Updated `ansible/roles/gdown/README.md` to reflect `pipx install gdown`.

* **Simplified Ansible tasks**

  * Removed shell-based installation logic and `--break-system-packages`.
  * Reduced complexity and improved idempotency.

## Motivation

* Align with best practices for installing Python CLI tools using `pipx`.
* Avoid modifying system Python environments.
* Eliminate special-case logic for Jazzy vs non-Jazzy distributions.
* Improve maintainability and clarity of the Ansible role.

## Testing

* Ansible role change only.
* No functional changes to runtime behavior beyond installation method.

## Notes for Reviewers

* Ensure `pipx` is available on target systems before running this role.
* Behavior should be consistent across all supported ROS distributions.
