### PR TITLE
docs(ansible): add recommended ccache configuration and usage guide

### DIFF
--- a/ansible/roles/build_tools/README.md
+++ b/ansible/roles/build_tools/README.md
@@ -11,9 +11,34 @@ This role installs build tools for building Autoware.
 ## Manual Installation
 
 ```bash
-# Update package lists
 sudo apt-get update
-
-# Install ccache
 sudo apt-get install -y ccache
 ```
+
+## Configuration (🆕 Recommended)
+
+> ℹ️ These steps differ slightly from the existing Ansible setup and represent the preferred configuration.  
+> The Ansible version will be updated to match the steps below.
+
+```bash
+# Make sure the ccache directory exists
+mkdir -p "$HOME/.cache/ccache"
+
+# Add the following lines to ~/.bashrc file
+export CMAKE_C_COMPILER_LAUNCHER=ccache
+export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+export CCACHE_DIR="$HOME/.cache/ccache/"
+export CCACHE_LOGFILE=/tmp/ccache.log
+```
+
+Configure ccache maximum size:
+`gedit $HOME/.cache/ccache/ccache.conf`
+
+Add the following lines and save the file:
+
+```bash
+# Set maximum cache size
+max_size = 15G
+```
+
+**Also see:** [🔗 Autoware Documentation / Using ccache to speed up compilation](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/others/advanced-usage-of-colcon/#using-ccache-to-speed-up-recompilation).


### PR DESCRIPTION
## Summary

- Related: https://github.com/autowarefoundation/autoware/issues/6695

This PR expands the build tools documentation by adding a recommended `ccache` configuration to improve build performance when compiling Autoware. The new section documents environment setup, cache sizing, and links to official Autoware guidance.

## Key Changes

* **Enhanced build tools documentation**

  * Added a new **Configuration (Recommended)** section to the `build_tools` role README.
  * Clearly separates basic installation from recommended usage.

* **Documented recommended `ccache` setup**

  * Environment variables for CMake compiler launchers.
  * Explicit cache directory and logging configuration.
  * Instructions for setting a maximum cache size.

* **Improved developer guidance**

  * Added a direct link to the official Autoware documentation on using `ccache`.
  * Included notes clarifying that the documented setup will become the Ansible default.

## Motivation

* Help developers take full advantage of `ccache` to significantly reduce rebuild times.
* Make performance-oriented configuration discoverable and easy to apply.
* Align local developer environments with upcoming Ansible changes.

## Testing

* Documentation-only change.
* No functional or behavioral changes to the build system.

## Notes for Reviewers

* The documented configuration intentionally differs from the current Ansible role.
* Follow-up work will update Ansible to match the recommended setup.
* Please review for clarity and consistency with Autoware build practices.