### PR TITLE
docs(ansible): improve geographiclib manual installation instructions

### DIFF
--- a/ansible/roles/geographiclib/README.md
+++ b/ansible/roles/geographiclib/README.md
@@ -7,7 +7,8 @@ None.
 ## Manual Installation
 
 ```bash
-sudo apt install geographiclib-tools
+sudo apt update
+sudo apt install -y geographiclib-tools
 
 # Add EGM2008 geoid grid to geographiclib
 sudo geographiclib-get-geoids egm2008-1


### PR DESCRIPTION
## Summary

- Related: https://github.com/autowarefoundation/autoware/issues/6695

This PR updates the GeographicLib Ansible role documentation to make the manual installation steps more robust and consistent with best practices.

## Key Changes

* Added `sudo apt update` before package installation.
* Added the `-y` flag to `apt install` for non-interactive installs.

## Motivation

* Prevents installation failures caused by outdated package indexes.
* Aligns the documentation with common CI and automation-friendly practices.
* Improves the copy-paste experience for users following the manual setup.

## Testing

* Documentation-only change.
* No functional or behavioral changes to the Ansible role.

## Notes for Reviewers

* Change is limited to README instructions.
* No impact on existing installations or automation.