### PR TITLE
docs(ansible): clarify rmw_implementation manual setup and ROS distro selection

### DIFF
--- a/ansible/roles/rmw_implementation/README.md
+++ b/ansible/roles/rmw_implementation/README.md
@@ -11,13 +11,29 @@ This role sets up ROS 2 RMW implementation following [this page](https://docs.ro
 
 ## Manual Installation
 
-For Universe, the `rosdistro` and `rmw_implementation` variable can also be found in:
-[../../playbooks/universe.yaml](../../playbooks/universe.yaml)
+## Set up the environment variables
+
+Choose **one** ROS distribution and run the corresponding command.
+
+### ROS 2 Humble
 
 ```bash
-wget -O /tmp/amd64.env https://raw.githubusercontent.com/autowarefoundation/autoware/main/amd64.env && source /tmp/amd64.env
+wget -O /tmp/amd64.env https://raw.githubusercontent.com/autowarefoundation/autoware/main/amd64.env && \
+source /tmp/amd64.env
+```
 
-# For details: https://docs.ros.org/en/humble/How-To-Guides/Working-with-multiple-RMW-implementations.html
+### ROS 2 Jazzy
+
+```bash
+wget -O /tmp/amd64.env https://raw.githubusercontent.com/autowarefoundation/autoware/main/amd64_jazzy.env && \
+source /tmp/amd64.env
+```
+
+## Install the RMW implementation
+
+For details: <https://docs.ros.org/en/humble/How-To-Guides/Working-with-multiple-RMW-implementations.html>
+
+```bash
 sudo apt update
 sudo apt install ros-${rosdistro}-${rmw_implementation//_/-}
 


### PR DESCRIPTION
## Summary

- Related: https://github.com/autowarefoundation/autoware/issues/6695

This PR improves the manual installation documentation for the RMW implementation role by clearly separating environment setup from package installation and adding explicit instructions for different ROS 2 distributions.

## Key Changes

* **Clarified environment setup**

  * Added a dedicated section for setting up environment variables.
  * Introduced separate instructions for:

    * **ROS 2 Humble**
    * **ROS 2 Jazzy**

* **Improved installation flow**

  * Split the manual installation steps into:

    * Environment variable setup
    * RMW implementation installation
  * Made the installation command easier to follow and reuse.

* **Documentation cleanup**

  * Converted inline comments into proper prose.
  * Replaced raw URLs with Markdown-friendly links.
  * Improved section headings for readability and consistency with other roles.

## Motivation

* Reduce ambiguity when setting up RMW implementations manually.
* Make ROS distribution selection explicit and less error-prone.
* Align documentation structure with other Ansible roles in the repository.
* Improve onboarding experience for new contributors.

## Testing

* Documentation-only changes.
* No functional changes to Ansible roles or runtime behavior.

## Notes for Reviewers

* Verify that the Humble and Jazzy instructions match the intended environment files.
* Confirm consistency with other role READMEs that reference `amd64.env`.