### PR TITLE
docs(ansible): update nvidia-container-toolkit manual installation steps

### DIFF
--- a/ansible/roles/nvidia_container_toolkit/README.md
+++ b/ansible/roles/nvidia_container_toolkit/README.md
@@ -6,21 +6,27 @@ This role installs [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-c
 
 None.
 
-## Manual Installation
+## Manual Installation (Recommended)
 
-Install Nvidia Container Toolkit:
+> ℹ️ The steps below may differ from the role implementation.  
+> They reflect the **most up-to-date and preferred procedure** for manual installation.  
+> The role will be updated to align with these steps.
 
 <!-- cspell:ignore Disp, Uncorr -->
 
 ```bash
-# Add NVIDIA container toolkit GPG key
-sudo apt-key adv --fetch-keys https://nvidia.github.io/libnvidia-container/gpgkey
-sudo gpg --no-default-keyring --keyring /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg --import /etc/apt/trusted.gpg
+# Install the prerequisites for the instructions below:
+sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+   curl \
+   gnupg2
 
-# Add NVIDIA container toolkit repository
-echo "deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://nvidia.github.io/libnvidia-container/stable/deb/$(dpkg --print-architecture) /" | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+# Configure the production repository:
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+  && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+    sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
 
-# Update the package list
+# Update the packages list from the repository:
 sudo apt-get update
 
 # Install NVIDIA Container Toolkit
@@ -33,26 +39,40 @@ sudo nvidia-ctk runtime configure --runtime=docker
 sudo systemctl restart docker
 
 # At this point, a working setup can be tested by running a base CUDA container:
-sudo docker run --rm --gpus all nvcr.io/nvidia/cuda:12.3.1-runtime-ubuntu20.04 nvidia-smi
+sudo docker run --rm --gpus all nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04 nvidia-smi
 
-# This should result in a console output shown below:
-# +-----------------------------------------------------------------------------+
-# | NVIDIA-SMI 545.23.08    Driver Version: 545.23.08    CUDA Version: 12.3.1   |
-# |-------------------------------+----------------------+----------------------+
-# | GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
-# | Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
-# |                               |                      |               MIG M. |
-# |===============================+======================+======================|
-# |   0  Tesla T4            On   | 00000000:00:1E.0 Off |                    0 |
-# | N/A   34C    P8     9W /  70W |      0MiB / 15109MiB |      0%      Default |
-# |                               |                      |                  N/A |
-# +-------------------------------+----------------------+----------------------+
+# ==========
+# == CUDA ==
+# ==========
 #
-# +-----------------------------------------------------------------------------+
-# | Processes:                                                                  |
-# |  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
-# |        ID   ID                                                   Usage      |
-# |=============================================================================|
-# |  No running processes found                                                 |
-# +-----------------------------------------------------------------------------+
+# CUDA Version 12.8.1
+#
+# Container image Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# This container image and its contents are governed by the NVIDIA Deep Learning Container License.
+# By pulling and using the container, you accept the terms and conditions of this license:
+# https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license
+#
+# A copy of this license is made available in this container at /NGC-DL-CONTAINER-LICENSE for your convenience.
+#
+# Thu Jan 15 19:48:46 2026
+# +-----------------------------------------------------------------------------------------+
+# | NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0     |
+# +-----------------------------------------+------------------------+----------------------+
+# | GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+# | Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+# |                                         |                        |               MIG M. |
+# |=========================================+========================+======================|
+# |   0  NVIDIA GeForce RTX 3090        On  |   00000000:2B:00.0  On |                  N/A |
+# |  0%   52C    P8             41W /  350W |     369MiB /  24576MiB |     31%      Default |
+# |                                         |                        |                  N/A |
+# +-----------------------------------------+------------------------+----------------------+
+#
+# +-----------------------------------------------------------------------------------------+
+# | Processes:                                                                              |
+# |  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+# |        ID   ID                                                               Usage      |
+# |=========================================================================================|
+# |  No running processes found                                                             |
+# +-----------------------------------------------------------------------------------------+
 ```


### PR DESCRIPTION
## Summary

- Related: https://github.com/autowarefoundation/autoware/issues/6695

This PR updates the manual installation instructions for the NVIDIA Container Toolkit to reflect the **current recommended upstream procedure**. The documentation now uses modern APT key handling, updated prerequisites, and a newer CUDA test container.

> ⚠️ These steps are explicitly marked as *recommended manual installation* and may differ from the current Ansible role implementation. The role will be aligned in a follow-up change.

## Key Changes

* **Clarified installation intent**

  * Renamed *Manual Installation* → **Manual Installation (Recommended)**.
  * Added a note explaining the temporary divergence from the Ansible role.

* **Modernized repository setup**

  * Replaced deprecated `apt-key` usage with `gpg --dearmor` and a signed APT source.
  * Added explicit prerequisites (`curl`, `gnupg2`).

* **Updated verification example**

  * Switched to a newer CUDA base image:

    * From `cuda:12.3.1-runtime-ubuntu20.04`
    * To `cuda:12.8.1-runtime-ubuntu24.04`
  * Updated sample `nvidia-smi` output accordingly.

## Motivation

* Align documentation with NVIDIA’s **current best practices**.
* Avoid deprecated APT workflows that may fail on newer systems.
* Provide a clearer, copy-paste–safe manual setup for users troubleshooting GPU/container issues.

## Testing

* Documentation-only change.
* Manual steps validated against current NVIDIA Container Toolkit instructions.

## Notes for Reviewers

* The Ansible role still uses older logic; this PR intentionally documents the *preferred* approach first.
* A follow-up PR will update the role implementation to match these steps.