### PR TITLE
docs(ansible): clarify tensorrt manual installation for Humble and Jazzy

### DIFF
--- a/ansible/roles/tensorrt/README.md
+++ b/ansible/roles/tensorrt/README.md
@@ -10,10 +10,27 @@ This role installs TensorRT following [the official NVIDIA TensorRT Installation
 
 ## Manual Installation
 
-```bash
-# For the environment variables
-wget -O /tmp/amd64.env https://raw.githubusercontent.com/autowarefoundation/autoware/main/amd64.env && source /tmp/amd64.env
+### Set up the environment variables
 
+Choose **one** ROS distribution and run the corresponding command.
+
+#### ROS 2 Humble
+
+```bash
+wget -O /tmp/amd64.env https://raw.githubusercontent.com/autowarefoundation/autoware/main/amd64.env && \
+source /tmp/amd64.env
+```
+
+#### ROS 2 Jazzy
+
+```bash
+wget -O /tmp/amd64.env https://raw.githubusercontent.com/autowarefoundation/autoware/main/amd64_jazzy.env && \
+source /tmp/amd64.env
+```
+
+### Install TensorRT
+
+```bash
 sudo apt-get install -y \
 libnvinfer10=${tensorrt_version} \
 libnvinfer-plugin10=${tensorrt_version} \


### PR DESCRIPTION
## Summary

- Related: https://github.com/autowarefoundation/autoware/issues/6695

This PR improves the TensorRT Ansible role documentation by clarifying manual installation steps and explicitly separating environment setup instructions for ROS 2 Humble and Jazzy.

## Key Changes

* **Clarified environment variable setup**

  * Added a dedicated “Set up the environment variables” section.
  * Split instructions by ROS distribution:

    * ROS 2 Humble uses `amd64.env`
    * ROS 2 Jazzy uses `amd64_jazzy.env`

* **Improved installation flow**

  * Introduced an explicit “Install TensorRT” section.
  * Makes the manual installation process easier to follow step by step.

## Motivation

* Reduce confusion when manually installing TensorRT across different ROS distributions.
* Make the documentation more consistent with other roles.
* Improve readability for new contributors and users setting up development environments.

## Testing

* Documentation-only changes.
* No changes to installation logic or Ansible tasks.

## Notes for Reviewers

* Please verify that the correct environment files are referenced for each ROS distribution.
* No functional or behavioral changes are expected.