### PR TITLE
chore(autoware.repos): bump eagleye version to support jazzy

### DIFF
--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -61,7 +61,7 @@ repositories:
   universe/external/eagleye:
     type: git
     url: https://github.com/MapIV/eagleye.git
-    version: c1919448336e86a8dd9c94a337032c05fcf6c381
+    version: 575136ebba99892946d36d8398f228aee2136af0
   universe/external/rtklib_ros_bridge:
     type: git
     url: https://github.com/MapIV/rtklib_ros_bridge.git


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware/issues/6695

## Changes

https://github.com/MapIV/eagleye/compare/c1919448336e86a8dd9c94a337032c05fcf6c381...575136ebba99892946d36d8398f228aee2136af0

Only contains this PR, shouldn't affect humble:
- https://github.com/MapIV/eagleye/pull/355

## How was this PR tested?

Locally builds on Jazzy.