### PR TITLE
chore(autoware.repos): bump llh_converter version to support jazzy

### DIFF
--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -69,7 +69,7 @@ repositories:
   universe/external/llh_converter:
     type: git
     url: https://github.com/MapIV/llh_converter.git
-    version: 07ad112b4f6b83eccd3a5f777bbe40ff01c67382
+    version: 4fc2a2e1bc9dcf3e6ab0a8085d8257168e160342
   universe/external/glog:  # TODO(Horibe): to use isGoogleInitialized() API in v0.6.0. Remove when the rosdep glog version is updated to v0.6.0 (already updated in Ubuntu 24.04)
     type: git
     url: https://github.com/tier4/glog.git


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware/issues/6695

## Changes

https://github.com/MapIV/llh_converter/compare/07ad112b4f6b83eccd3a5f777bbe40ff01c67382...4fc2a2e1bc9dcf3e6ab0a8085d8257168e160342

Only contains this PR, shouldn't affect humble:
- https://github.com/MapIV/llh_converter/pull/25

## How was this PR tested?

Locally builds on Jazzy.