### PR TITLE
feat: add universe docker image build process for jazzy universe repo ci

### DIFF
--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -15,6 +15,10 @@ inputs:
     default: 2
     description: Maximum parallelism for buildkitd.
     required: false
+  suffix:
+    description: Suffix for image tags (e.g., -jazzy).
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -90,9 +94,9 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
         tags: |
-          type=raw,value=universe-common-devel-cuda-${{ inputs.platform }}
-          type=raw,value=universe-common-devel-cuda-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,prefix=universe-common-devel-cuda-,suffix=-${{ inputs.platform }}
+          type=raw,value=universe-common-devel-cuda${{ inputs.suffix }}-${{ inputs.platform }}
+          type=raw,value=universe-common-devel-cuda-${{ steps.date.outputs.date }}${{ inputs.suffix }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-common-devel-cuda-,suffix=${{ inputs.suffix }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-common-devel-cuda
         flavor: |
           latest=false
@@ -103,9 +107,9 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
         tags: |
-          type=raw,value=universe-sensing-perception-devel-cuda-${{ inputs.platform }}
-          type=raw,value=universe-sensing-perception-devel-cuda-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,prefix=universe-sensing-perception-devel-cuda-,suffix=-${{ inputs.platform }}
+          type=raw,value=universe-sensing-perception-devel-cuda${{ inputs.suffix }}-${{ inputs.platform }}
+          type=raw,value=universe-sensing-perception-devel-cuda-${{ steps.date.outputs.date }}${{ inputs.suffix }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-sensing-perception-devel-cuda-,suffix=${{ inputs.suffix }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-sensing-perception-devel-cuda
         flavor: |
           latest=false
@@ -116,9 +120,9 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
         tags: |
-          type=raw,value=universe-sensing-perception-cuda-${{ inputs.platform }}
-          type=raw,value=universe-sensing-perception-cuda-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,prefix=universe-sensing-perception-cuda-,suffix=-${{ inputs.platform }}
+          type=raw,value=universe-sensing-perception-cuda${{ inputs.suffix }}-${{ inputs.platform }}
+          type=raw,value=universe-sensing-perception-cuda-${{ steps.date.outputs.date }}${{ inputs.suffix }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-sensing-perception-cuda-,suffix=${{ inputs.suffix }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-sensing-perception-cuda
         flavor: |
           latest=false
@@ -129,9 +133,9 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
         tags: |
-          type=raw,value=universe-devel-cuda-${{ inputs.platform }}
-          type=raw,value=universe-devel-cuda-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,prefix=universe-devel-cuda-,suffix=-${{ inputs.platform }}
+          type=raw,value=universe-devel-cuda${{ inputs.suffix }}-${{ inputs.platform }}
+          type=raw,value=universe-devel-cuda-${{ steps.date.outputs.date }}${{ inputs.suffix }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-devel-cuda-,suffix=${{ inputs.suffix }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-devel-cuda
         flavor: |
           latest=false
@@ -142,9 +146,9 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
         tags: |
-          type=raw,value=universe-cuda-${{ inputs.platform }}
-          type=raw,value=universe-cuda-${{ steps.date.outputs.date }}-${{ inputs.platform }}
-          type=ref,event=tag,prefix=universe-cuda-,suffix=-${{ inputs.platform }}
+          type=raw,value=universe-cuda${{ inputs.suffix }}-${{ inputs.platform }}
+          type=raw,value=universe-cuda-${{ steps.date.outputs.date }}${{ inputs.suffix }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-cuda-,suffix=${{ inputs.suffix }}-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-cuda
         flavor: |
           latest=false

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -41,12 +41,6 @@ runs:
         vcs import --shallow --force src < ${{ inputs.additional-repos }}
       shell: bash
 
-    - name: Ensure required directories exist
-      run: |
-        # Create tools directory if it doesn't exist to avoid Docker mount errors
-        mkdir -p src/universe/autoware_universe/tools
-      shell: bash
-
     - name: Cache ccache
       uses: actions/cache@v4
       if: ${{ github.ref == 'refs/heads/main'}}

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -41,6 +41,12 @@ runs:
         vcs import --shallow --force src < ${{ inputs.additional-repos }}
       shell: bash
 
+    - name: Ensure required directories exist
+      run: |
+        # Create tools directory if it doesn't exist to avoid Docker mount errors
+        mkdir -p src/universe/autoware_universe/tools
+      shell: bash
+
     - name: Cache ccache
       uses: actions/cache@v4
       if: ${{ github.ref == 'refs/heads/main'}}

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -315,7 +315,7 @@ jobs:
           (github.event_name == 'push' && github.ref_type == 'tag') }}
         uses: ./.github/actions/free-disk-space
 
-      - name: Build 'Autoware Jazzy Core' without CUDA
+      - name: Build 'Autoware Jazzy Universe' without CUDA
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'push' && github.ref_type == 'tag') }}
@@ -327,13 +327,85 @@ jobs:
             *.platform=${{ matrix.arch-platform }}
             *.args.ROS_DISTRO=${{ needs.load-env-jazzy.outputs.rosdistro }}
             *.args.AUTOWARE_BASE_IMAGE=${{ needs.load-env-jazzy.outputs.autoware_base_image }}
+            *.args.AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env-jazzy.outputs.autoware_base_cuda_image }}
             *.args.LIB_DIR=${{ matrix.lib-dir }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-${{ github.ref_name }}
             *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-main
             *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-${{ github.ref_name }},mode=max
           set-latest: false
           suffix: -jazzy
-          core-only: true
+
+      - name: Show disk space
+        if: always()
+        run: |
+          df -h
+
+  docker-build-and-push-jazzy-cuda:
+    needs: [load-env-jazzy, docker-build-and-push-jazzy]
+    strategy:
+      matrix:
+        platform: [amd64]
+        include:
+          - platform: amd64
+            runner: [self-hosted, Linux, X64]
+            arch-platform: linux/amd64
+            lib-dir: x86_64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      # https://github.com/actions/checkout/issues/211
+      - name: Change permission of workspace
+        run: |
+          sudo chown -R $USER:$USER ${{ github.workspace }}
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set git config
+        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get changed files
+        id: changed-files
+        uses: step-security/changed-files@v46
+        with:
+          files: |
+            *.env
+            *.repos
+            .github/actions/combine-multi-arch-images/action.yaml
+            .github/actions/docker-build-and-push*/action.yaml
+            .github/workflows/docker-build-and-push.yaml
+            ansible-galaxy-requirements.yaml
+            ansible/**
+            docker/**
+
+      - name: Free disk space
+        if: ${{ runner.environment == 'github-hosted' &&
+          (steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'push' && github.ref_type == 'tag')) }}
+        uses: ./.github/actions/free-disk-space
+
+      - name: Build 'Autoware Jazzy Universe' with CUDA
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'push' && github.ref_type == 'tag') }}
+        uses: ./.github/actions/docker-build-and-push-cuda
+        with:
+          platform: ${{ matrix.platform }}
+          target-image: autoware
+          build-args: |
+            *.platform=${{ matrix.arch-platform }}
+            *.args.ROS_DISTRO=${{ needs.load-env-jazzy.outputs.rosdistro }}
+            *.args.BASE_IMAGE=${{ needs.load-env-jazzy.outputs.base_image }}
+            *.args.AUTOWARE_BASE_IMAGE=${{ needs.load-env-jazzy.outputs.autoware_base_image }}
+            *.args.AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env-jazzy.outputs.autoware_base_cuda_image }}
+            *.args.LIB_DIR=${{ matrix.lib-dir }}
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-cuda-${{ github.ref_name }}
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-cuda-main
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache:${{ matrix.platform }}-jazzy-cuda-${{ github.ref_name }},mode=max
+          suffix: -jazzy
+
       - name: Show disk space
         if: always()
         run: |
@@ -346,7 +418,19 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Combine multi arch images for 'autoware'
+      - name: Combine multi arch images for 'autoware' Jazzy
+        uses: ./.github/actions/combine-multi-arch-images
+        with:
+          package-name: autoware
+
+  update-docker-manifest-jazzy-cuda:
+    needs: [docker-build-and-push-jazzy-cuda]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Combine multi arch images for 'autoware' Jazzy with CUDA
         uses: ./.github/actions/combine-multi-arch-images
         with:
           package-name: autoware

--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -50,6 +50,11 @@ jobs:
             lib-dir: aarch64
     runs-on: ${{ fromJson(matrix.runner) }}
     steps:
+      # https://github.com/actions/checkout/issues/211
+      - name: Change permission of workspace
+        run: |
+          sudo chown -R $USER:$USER ${{ github.workspace }}
+
       - name: Check out repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -28,27 +28,66 @@ jobs:
       github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/load-env.yaml
 
-  docker-build:
+  docker-build-main:
+    name: docker-build (main)
     needs: load-env
-    strategy:
-      fail-fast: false
-      matrix:
-        build-type: [main, nightly, main-arm64]
-        include:
-          - build-type: main
-            platform: amd64
-            runner: "['self-hosted','Linux','X64']"
-            lib-dir: x86_64
-            container: ubuntu:22.04
-          - build-type: nightly
-            platform: amd64
-            runner: "['ubuntu-24.04']"
-            lib-dir: x86_64
-          - build-type: main-arm64
-            platform: arm64
-            runner: "['ubuntu-24.04-arm']"
-            lib-dir: aarch64
-    runs-on: ${{ fromJson(matrix.runner) }}
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      # https://github.com/actions/checkout/issues/211
+      - name: Change permission of workspace
+        run: |
+          sudo chown -R $USER:$USER ${{ github.workspace }}
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set git config
+        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get changed files
+        id: changed-files
+        uses: step-security/changed-files@v46
+        with:
+          files: |
+            *.env
+            *.repos
+            .github/actions/docker-build/action.yaml
+            .github/workflows/health-check.yaml
+            ansible-galaxy-requirements.yaml
+            ansible/**
+            docker/**
+            setup-dev-env.sh
+
+      - name: Show disk space
+        if: always()
+        run: |
+          df -h
+
+      - name: Build 'Autoware'
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch' }}
+        uses: ./.github/actions/docker-build
+        with:
+          platform: amd64
+          cache-tag-suffix: main
+          build-args: |
+            ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
+            AUTOWARE_BASE_IMAGE=${{ needs.load-env.outputs.autoware_base_image }}
+            AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env.outputs.autoware_base_cuda_image }}
+            LIB_DIR=x86_64
+
+      - name: Show disk space
+        if: always()
+        run: |
+          df -h
+
+  docker-build-arm64:
+    name: docker-build (main-arm64)
+    needs: load-env
+    runs-on: ubuntu-24.04-arm
     steps:
       # https://github.com/actions/checkout/issues/211
       - name: Change permission of workspace
@@ -83,8 +122,7 @@ jobs:
           df -h
 
       - name: Free disk space
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' &&
-          matrix.build-type != 'main' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         uses: ./.github/actions/free-disk-space
 
       - name: Build 'Autoware'
@@ -93,14 +131,74 @@ jobs:
           github.event_name == 'workflow_dispatch' }}
         uses: ./.github/actions/docker-build
         with:
-          platform: ${{ matrix.platform }}
-          cache-tag-suffix: ${{ matrix.build-type }}
-          additional-repos: ${{ matrix.build-type == 'nightly' && 'repositories/autoware-nightly.repos' || '' }}
+          platform: arm64
+          cache-tag-suffix: main-arm64
           build-args: |
             ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
             AUTOWARE_BASE_IMAGE=${{ needs.load-env.outputs.autoware_base_image }}
             AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env.outputs.autoware_base_cuda_image }}
-            LIB_DIR=${{ matrix.lib-dir }}
+            LIB_DIR=aarch64
+
+      - name: Show disk space
+        if: always()
+        run: |
+          df -h
+
+  docker-build-nightly:
+    name: docker-build (nightly)
+    needs: [load-env, docker-build-arm64]
+    runs-on: ubuntu-24.04
+    steps:
+      # https://github.com/actions/checkout/issues/211
+      - name: Change permission of workspace
+        run: |
+          sudo chown -R $USER:$USER ${{ github.workspace }}
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set git config
+        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get changed files
+        id: changed-files
+        uses: step-security/changed-files@v46
+        with:
+          files: |
+            *.env
+            *.repos
+            .github/actions/docker-build/action.yaml
+            .github/workflows/health-check.yaml
+            ansible-galaxy-requirements.yaml
+            ansible/**
+            docker/**
+            setup-dev-env.sh
+
+      - name: Show disk space
+        if: always()
+        run: |
+          df -h
+
+      - name: Free disk space
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        uses: ./.github/actions/free-disk-space
+
+      - name: Build 'Autoware'
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch' }}
+        uses: ./.github/actions/docker-build
+        with:
+          platform: amd64
+          cache-tag-suffix: nightly
+          additional-repos: repositories/autoware-nightly.repos
+          build-args: |
+            ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
+            AUTOWARE_BASE_IMAGE=${{ needs.load-env.outputs.autoware_base_image }}
+            AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env.outputs.autoware_base_cuda_image }}
+            LIB_DIR=x86_64
 
       - name: Show disk space
         if: always()

--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -28,66 +28,27 @@ jobs:
       github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/load-env.yaml
 
-  docker-build-main:
-    name: docker-build (main)
+  docker-build:
     needs: load-env
-    runs-on: [self-hosted, Linux, X64]
-    steps:
-      # https://github.com/actions/checkout/issues/211
-      - name: Change permission of workspace
-        run: |
-          sudo chown -R $USER:$USER ${{ github.workspace }}
-
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set git config
-        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get changed files
-        id: changed-files
-        uses: step-security/changed-files@v46
-        with:
-          files: |
-            *.env
-            *.repos
-            .github/actions/docker-build/action.yaml
-            .github/workflows/health-check.yaml
-            ansible-galaxy-requirements.yaml
-            ansible/**
-            docker/**
-            setup-dev-env.sh
-
-      - name: Show disk space
-        if: always()
-        run: |
-          df -h
-
-      - name: Build 'Autoware'
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
-          github.event_name == 'schedule' ||
-          github.event_name == 'workflow_dispatch' }}
-        uses: ./.github/actions/docker-build
-        with:
-          platform: amd64
-          cache-tag-suffix: main
-          build-args: |
-            ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
-            AUTOWARE_BASE_IMAGE=${{ needs.load-env.outputs.autoware_base_image }}
-            AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env.outputs.autoware_base_cuda_image }}
-            LIB_DIR=x86_64
-
-      - name: Show disk space
-        if: always()
-        run: |
-          df -h
-
-  docker-build-arm64:
-    name: docker-build (main-arm64)
-    needs: load-env
-    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        build-type: [main, nightly, main-arm64]
+        include:
+          - build-type: main
+            platform: amd64
+            runner: "['self-hosted','Linux','X64']"
+            lib-dir: x86_64
+            container: ubuntu:22.04
+          - build-type: nightly
+            platform: amd64
+            runner: "['ubuntu-24.04']"
+            lib-dir: x86_64
+          - build-type: main-arm64
+            platform: arm64
+            runner: "['ubuntu-24.04-arm']"
+            lib-dir: aarch64
+    runs-on: ${{ fromJson(matrix.runner) }}
     steps:
       # https://github.com/actions/checkout/issues/211
       - name: Change permission of workspace
@@ -122,7 +83,8 @@ jobs:
           df -h
 
       - name: Free disk space
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' &&
+          matrix.build-type != 'main' }}
         uses: ./.github/actions/free-disk-space
 
       - name: Build 'Autoware'
@@ -131,74 +93,14 @@ jobs:
           github.event_name == 'workflow_dispatch' }}
         uses: ./.github/actions/docker-build
         with:
-          platform: arm64
-          cache-tag-suffix: main-arm64
+          platform: ${{ matrix.platform }}
+          cache-tag-suffix: ${{ matrix.build-type }}
+          additional-repos: ${{ matrix.build-type == 'nightly' && 'repositories/autoware-nightly.repos' || '' }}
           build-args: |
             ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
             AUTOWARE_BASE_IMAGE=${{ needs.load-env.outputs.autoware_base_image }}
             AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env.outputs.autoware_base_cuda_image }}
-            LIB_DIR=aarch64
-
-      - name: Show disk space
-        if: always()
-        run: |
-          df -h
-
-  docker-build-nightly:
-    name: docker-build (nightly)
-    needs: [load-env, docker-build-arm64]
-    runs-on: ubuntu-24.04
-    steps:
-      # https://github.com/actions/checkout/issues/211
-      - name: Change permission of workspace
-        run: |
-          sudo chown -R $USER:$USER ${{ github.workspace }}
-
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set git config
-        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get changed files
-        id: changed-files
-        uses: step-security/changed-files@v46
-        with:
-          files: |
-            *.env
-            *.repos
-            .github/actions/docker-build/action.yaml
-            .github/workflows/health-check.yaml
-            ansible-galaxy-requirements.yaml
-            ansible/**
-            docker/**
-            setup-dev-env.sh
-
-      - name: Show disk space
-        if: always()
-        run: |
-          df -h
-
-      - name: Free disk space
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
-        uses: ./.github/actions/free-disk-space
-
-      - name: Build 'Autoware'
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
-          github.event_name == 'schedule' ||
-          github.event_name == 'workflow_dispatch' }}
-        uses: ./.github/actions/docker-build
-        with:
-          platform: amd64
-          cache-tag-suffix: nightly
-          additional-repos: repositories/autoware-nightly.repos
-          build-args: |
-            ROS_DISTRO=${{ needs.load-env.outputs.rosdistro }}
-            AUTOWARE_BASE_IMAGE=${{ needs.load-env.outputs.autoware_base_image }}
-            AUTOWARE_BASE_CUDA_IMAGE=${{ needs.load-env.outputs.autoware_base_cuda_image }}
-            LIB_DIR=x86_64
+            LIB_DIR=${{ matrix.lib-dir }}
 
       - name: Show disk space
         if: always()

--- a/amd64_jazzy.env
+++ b/amd64_jazzy.env
@@ -5,7 +5,7 @@ rmw_implementation=rmw_cyclonedds_cpp
 # Jazzy-specific overrides (will be set by build.sh)
 base_image=ros:jazzy-ros-base-noble
 autoware_base_image=ghcr.io/autowarefoundation/autoware-base:latest-jazzy
-autoware_base_cuda_image=ghcr.io/autowarefoundation/autoware-base:jazzy-cuda-latest
+autoware_base_cuda_image=ghcr.io/autowarefoundation/autoware-base:cuda-latest-jazzy
 
 cuda_version=12.8
 tensorrt_version=10.8.0.43-1+cuda12.8

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -157,6 +157,7 @@ FROM rosdep-depend AS rosdep-universe-api-depend
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
+COPY src/universe/autoware_universe/launch/tier4_autoware_api_launch /autoware/src/universe/autoware_universe/launch/tier4_autoware_api_launch
 COPY src/universe/autoware_universe/system/autoware_default_adapi_universe /autoware/src/universe/autoware_universe/system/autoware_default_adapi_universe
 COPY src/core/autoware_core/api/autoware_adapi_adaptors /autoware/src/core/autoware_core/api/autoware_adapi_adaptors
 COPY src/universe/autoware_universe/system/autoware_diagnostic_graph_utils /autoware/src/universe/autoware_universe/system/autoware_diagnostic_graph_utils
@@ -268,6 +269,7 @@ RUN --mount=type=cache,target="${CCACHE_DIR}" \
   --mount=type=bind,source=src/universe/external/muSSP,target=/autoware/src/universe/external/muSSP \
   --mount=type=bind,source=src/universe/external/pointcloud_to_laserscan,target=/autoware/src/universe/external/pointcloud_to_laserscan \
   --mount=type=bind,source=src/universe/external/rtklib_ros_bridge,target=/autoware/src/universe/external/rtklib_ros_bridge \
+  --mount=type=bind,source=src/universe/external/tier4_ad_api_adaptor,target=/autoware/src/universe/external/tier4_ad_api_adaptor \
   --mount=type=bind,source=src/universe/external/tier4_autoware_msgs,target=/autoware/src/universe/external/tier4_autoware_msgs \
   --mount=type=bind,source=src/middleware/external,target=/autoware/src/middleware/external \
   --mount=type=bind,source=src/launcher,target=/autoware/src/launcher \
@@ -486,6 +488,7 @@ RUN --mount=type=ssh \
 
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
+  --mount=type=bind,source=src/universe/autoware_universe/launch/tier4_autoware_api_launch,target=/autoware/src/universe/autoware_universe/launch/tier4_autoware_api_launch \
   --mount=type=bind,source=src/universe/autoware_universe/system/autoware_default_adapi_universe,target=/autoware/src/universe/autoware_universe/system/autoware_default_adapi_universe \
   --mount=type=bind,source=src/core/autoware_core/api/autoware_adapi_adaptors,target=/autoware/src/core/autoware_core/api/autoware_adapi_adaptors \
   --mount=type=bind,source=src/universe/autoware_universe/system/autoware_diagnostic_graph_utils,target=/autoware/src/universe/autoware_universe/system/autoware_diagnostic_graph_utils \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -162,6 +162,7 @@ COPY src/universe/autoware_universe/system/autoware_default_adapi_universe /auto
 COPY src/core/autoware_core/api/autoware_adapi_adaptors /autoware/src/core/autoware_core/api/autoware_adapi_adaptors
 COPY src/universe/autoware_universe/system/autoware_diagnostic_graph_utils /autoware/src/universe/autoware_universe/system/autoware_diagnostic_graph_utils
 COPY src/core/autoware_core/map/autoware_map_height_fitter /autoware/src/core/autoware_core/map/autoware_map_height_fitter
+COPY src/universe/autoware_universe/evaluator/autoware_evaluation_adapter /autoware/src/universe/autoware_universe/evaluator/autoware_evaluation_adapter
 
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-api-depend-packages.txt \
@@ -493,6 +494,7 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,source=src/core/autoware_core/api/autoware_adapi_adaptors,target=/autoware/src/core/autoware_core/api/autoware_adapi_adaptors \
   --mount=type=bind,source=src/universe/autoware_universe/system/autoware_diagnostic_graph_utils,target=/autoware/src/universe/autoware_universe/system/autoware_diagnostic_graph_utils \
   --mount=type=bind,source=src/core/autoware_core/map/autoware_map_height_fitter,target=/autoware/src/core/autoware_core/map/autoware_map_height_fitter \
+  --mount=type=bind,source=src/universe/autoware_universe/evaluator/autoware_evaluation_adapter,target=/autoware/src/universe/autoware_universe/evaluator/autoware_evaluation_adapter \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
   && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -157,7 +157,6 @@ FROM rosdep-depend AS rosdep-universe-api-depend
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
-COPY src/universe/autoware_universe/launch/tier4_autoware_api_launch /autoware/src/universe/autoware_universe/launch/tier4_autoware_api_launch
 COPY src/universe/autoware_universe/system/autoware_default_adapi_universe /autoware/src/universe/autoware_universe/system/autoware_default_adapi_universe
 COPY src/core/autoware_core/api/autoware_adapi_adaptors /autoware/src/core/autoware_core/api/autoware_adapi_adaptors
 COPY src/universe/autoware_universe/system/autoware_diagnostic_graph_utils /autoware/src/universe/autoware_universe/system/autoware_diagnostic_graph_utils
@@ -269,7 +268,6 @@ RUN --mount=type=cache,target="${CCACHE_DIR}" \
   --mount=type=bind,source=src/universe/external/muSSP,target=/autoware/src/universe/external/muSSP \
   --mount=type=bind,source=src/universe/external/pointcloud_to_laserscan,target=/autoware/src/universe/external/pointcloud_to_laserscan \
   --mount=type=bind,source=src/universe/external/rtklib_ros_bridge,target=/autoware/src/universe/external/rtklib_ros_bridge \
-  --mount=type=bind,source=src/universe/external/tier4_ad_api_adaptor,target=/autoware/src/universe/external/tier4_ad_api_adaptor \
   --mount=type=bind,source=src/universe/external/tier4_autoware_msgs,target=/autoware/src/universe/external/tier4_autoware_msgs \
   --mount=type=bind,source=src/middleware/external,target=/autoware/src/middleware/external \
   --mount=type=bind,source=src/launcher,target=/autoware/src/launcher \
@@ -488,7 +486,6 @@ RUN --mount=type=ssh \
 
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
-  --mount=type=bind,source=src/universe/autoware_universe/launch/tier4_autoware_api_launch,target=/autoware/src/universe/autoware_universe/launch/tier4_autoware_api_launch \
   --mount=type=bind,source=src/universe/autoware_universe/system/autoware_default_adapi_universe,target=/autoware/src/universe/autoware_universe/system/autoware_default_adapi_universe \
   --mount=type=bind,source=src/core/autoware_core/api/autoware_adapi_adaptors,target=/autoware/src/core/autoware_core/api/autoware_adapi_adaptors \
   --mount=type=bind,source=src/universe/autoware_universe/system/autoware_diagnostic_graph_utils,target=/autoware/src/universe/autoware_universe/system/autoware_diagnostic_graph_utils \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -530,7 +530,6 @@ RUN --mount=type=cache,target="${CCACHE_DIR}" \
   --mount=type=bind,source=src/universe/autoware_universe/evaluator,target=/autoware/src/universe/autoware_universe/evaluator \
   --mount=type=bind,source=src/universe/autoware_universe/launch,target=/autoware/src/universe/autoware_universe/launch \
   --mount=type=bind,source=src/universe/autoware_universe/simulator,target=/autoware/src/universe/autoware_universe/simulator \
-  --mount=type=bind,source=src/universe/autoware_universe/tools,target=/autoware/src/universe/autoware_universe/tools \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
   && /autoware/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -162,7 +162,6 @@ COPY src/universe/autoware_universe/system/autoware_default_adapi_universe /auto
 COPY src/core/autoware_core/api/autoware_adapi_adaptors /autoware/src/core/autoware_core/api/autoware_adapi_adaptors
 COPY src/universe/autoware_universe/system/autoware_diagnostic_graph_utils /autoware/src/universe/autoware_universe/system/autoware_diagnostic_graph_utils
 COPY src/core/autoware_core/map/autoware_map_height_fitter /autoware/src/core/autoware_core/map/autoware_map_height_fitter
-COPY src/universe/autoware_universe/evaluator/autoware_evaluation_adapter /autoware/src/universe/autoware_universe/evaluator/autoware_evaluation_adapter
 
 RUN /autoware/resolve_rosdep_keys.sh /autoware/src ${ROS_DISTRO} \
   > /rosdep-universe-api-depend-packages.txt \
@@ -494,7 +493,6 @@ RUN --mount=type=cache,target=${CCACHE_DIR} \
   --mount=type=bind,source=src/core/autoware_core/api/autoware_adapi_adaptors,target=/autoware/src/core/autoware_core/api/autoware_adapi_adaptors \
   --mount=type=bind,source=src/universe/autoware_universe/system/autoware_diagnostic_graph_utils,target=/autoware/src/universe/autoware_universe/system/autoware_diagnostic_graph_utils \
   --mount=type=bind,source=src/core/autoware_core/map/autoware_map_height_fitter,target=/autoware/src/core/autoware_core/map/autoware_map_height_fitter \
-  --mount=type=bind,source=src/universe/autoware_universe/evaluator/autoware_evaluation_adapter,target=/autoware/src/universe/autoware_universe/evaluator/autoware_evaluation_adapter \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \
   && /autoware/build_and_clean.sh ${CCACHE_DIR} /opt/autoware


### PR DESCRIPTION
## Description

Add support for building Jazzy version of `universe-devel` and `universe-devel-cuda` Docker images. The images are used to complete universe jazzy ci.
parent issue -- https://github.com/autowarefoundation/autoware_universe/issues/11418
### Changes

**`.github/workflows/docker-build-and-push.yaml`**
- Modified `docker-build-and-push-jazzy` job to build full universe images (removed `core-only: true`)
- Added `AUTOWARE_BASE_CUDA_IMAGE` build argument for Jazzy builds
- Added new `docker-build-and-push-jazzy-cuda` job for building CUDA-enabled Jazzy images
- Added new `update-docker-manifest-jazzy-cuda` job for combining multi-arch CUDA images

**`.github/actions/docker-build-and-push-cuda/action.yaml`**
- Added `suffix` input parameter to support image tag suffixes (e.g., `-jazzy`)
- Updated all Docker meta tags to include the suffix parameter
- Fixed tag naming order to be consistent with base images (e.g., `universe-devel-cuda-jazzy` instead of `universe-devel-jazzy-cuda`)

**`amd64_jazzy.env`**
- Fixed CUDA base image tag from `jazzy-cuda-latest` to `cuda-latest-jazzy` to match actual image naming

### New Images

| Image | Type | Purpose |
|-------|------|---------|
| `autoware:universe-devel-jazzy` | Development | CI builds for autoware_universe |
| `autoware:universe-devel-cuda-jazzy` | Development + CUDA | CI builds with CUDA support |
| `autoware:universe-jazzy` | Runtime | Production deployment |
| `autoware:universe-cuda-jazzy` | Runtime + CUDA | Production deployment with GPU |

### Dependencies

This PR requires the following base images (confirmed available):
- `ghcr.io/autowarefoundation/autoware-base:latest-jazzy` ✅
- `ghcr.io/autowarefoundation/autoware-base:cuda-latest-jazzy` ✅

## How was this PR tested?
pass test online on autoware official git acition

additional modification
~~When the run:health-check label triggers the workflow, the three docker-build tasks (main, nightly, main-arm64) execute in parallel. On self-hosted runners, each job startup executes /opt/runner-scripts/cleanup_script.sh, which:
Keeps the last 15 Docker images
Deletes the rest
Problem: When multiple jobs start concurrently on the same or different self-hosted runners, the cleanup script attempts to delete the moby/buildkit:buildx-stable-1 image that is being used by other jobs (buildx builder container). Docker refuses the deletion, causing the script to exit with code 123 and the job to fail.~~

~~1. remove docker build dependency to tier4-ad-api-adapter according to pr  https://github.com/autowarefoundation/autoware/pull/6690~~

