### PR TITLE
ci(setup-universe.yaml): run in container for humble and jazzy

### DIFF
--- a/.github/workflows/setup-universe.yaml
+++ b/.github/workflows/setup-universe.yaml
@@ -9,18 +9,34 @@ concurrency:
 
 jobs:
   setup-universe:
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, X64]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: ubuntu:22.04
+            ros_distro: humble
+          - image: ubuntu:24.04
+            ros_distro: jazzy
+    container:
+      image: ${{ matrix.image }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Free disk space
-        uses: ./.github/actions/free-disk-space
+        uses: actions/checkout@v6
 
       - name: Show disk space
         if: always()
         run: |
           df -h
+
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y git sudo curl ca-certificates apt-utils
+
+      - name: Install tzdata non-interactively
+        run: |
+          DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
 
       - name: Set git config
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1
@@ -29,4 +45,4 @@ jobs:
 
       - name: Run setup script
         run: |
-          ./setup-dev-env.sh -y -v universe
+          ./setup-dev-env.sh --ros-distro ${{ matrix.ros_distro }} -y -v universe

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -139,6 +139,7 @@
   when: agnocast_is_container
 
 - name: Handle kernel-related tasks (headers + kmod, non-container only)
+  when: not agnocast_is_container
   block:
     - name: Check if linux-headers package is available
       ansible.builtin.shell: |


### PR DESCRIPTION
## Summary

- **Related PR:** https://github.com/autowarefoundation/autoware/pull/6746#issuecomment-3794729783

This PR updates the `setup-universe` workflow to implement a matrix build strategy, enabling testing on both Ubuntu 22.04 (ROS 2 Humble) and Ubuntu 24.04 (ROS 2 Jazzy).

To ensure a clean and reproducible build environment, the workflow has been migrated to run inside bare Docker containers on self-hosted runners. This avoids conflicts caused by pre-installed tools on standard GitHub runners (e.g., non-standard `pipx` installations) and better reflects a fresh user environment. Additionally, this PR fixes a logic gap in the Ansible `agnocast` role where kernel tasks were incorrectly attempted when running inside a container.

## Key Changes

### Workflow Updates (`.github/workflows/setup-universe.yaml`)

* **Matrix Strategy:** Implemented a build matrix to run tests against:
   * `ubuntu:22.04` with `ros_distro: humble`
   * `ubuntu:24.04` with `ros_distro: jazzy`


* **Clean Container Environment:** Switched from standard GitHub-hosted runners to `[self-hosted, Linux, X64]` running directly inside raw Docker images (`image: ${{ matrix.image }}`).
   * *Reason:* GitHub-hosted runners come with pre-installed dependencies that often differ from a standard user setup. Running in a bare container ensures the setup script works in a neutral environment.
   * Also due to space limitations. Since we are running in container, we cannot use free-disk-space action anymore.
   * 🎗️ Also this workflow is downloading all artifacts, that might be a bad idea considering cloud costs. 
* **Dependency Management:** Added steps to manually install essential dependencies (`git`, `sudo`, `curl`) required for the bare container environments.
* **Non-Interactive Configuration:** Explicitly installed `tzdata` with `DEBIAN_FRONTEND=noninteractive` to prevent the CI pipeline from hanging on timezone selection prompts.
* **Script Arguments:** Updated the `./setup-dev-env.sh` call to dynamically pass the `--ros-distro` argument based on the matrix context.

### Ansible Updates (`ansible/roles/agnocast/tasks/main.yaml`)

* **Container Logic Fix:** Added a conditional check (`when: not agnocast_is_container`) to the "Handle kernel-related tasks" block.
   * *Reason:* Previously, this role was likely not tested in containerized environments, causing the logic to overlook that kernel headers/modules cannot be modified inside a container. This ensures the tasks are properly skipped when `agnocast_is_container` is detected.