### PR TITLE
fix(ansible): fix ansible gdown role

### DIFF
--- a/ansible/roles/gdown/tasks/main.yaml
+++ b/ansible/roles/gdown/tasks/main.yaml
@@ -1,3 +1,10 @@
+- name: Install pipx
+  become: true
+  ansible.builtin.apt:
+    name: pipx
+    state: latest
+    update_cache: true
+
 - name: Install gdown to download files from CMakeLists.txt
   community.general.pipx:
     name: gdown


### PR DESCRIPTION
## Description

Fix this error. This probably happens when it runs without dev_tools role. 
Related PR: https://github.com/autowarefoundation/autoware/pull/6746

```
TASK [autoware.dev_env.gdown : Install gdown to download files from CMakeLists.txt] ***
fatal: [localhost]: FAILED! => {"changed": false, "cmd": "/usr/bin/pipx list --include-injected --json", "msg": "[Errno 2] No such file or directory: b'/usr/bin/pipx'", "rc": 2, "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
```

## How was this PR tested?

This is another feature branch but I test it simultaneously.
https://evaluation.tier4.jp/evaluation/reports/494e28b6-ac15-5a67-a965-8db9e513b4fd?project_id=awf