### PR TITLE
feat: remove tier4_ad_api_adaptor

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -270,7 +270,6 @@ RUN --mount=type=cache,target="${CCACHE_DIR}" \
   --mount=type=bind,source=src/universe/external/muSSP,target=/autoware/src/universe/external/muSSP \
   --mount=type=bind,source=src/universe/external/pointcloud_to_laserscan,target=/autoware/src/universe/external/pointcloud_to_laserscan \
   --mount=type=bind,source=src/universe/external/rtklib_ros_bridge,target=/autoware/src/universe/external/rtklib_ros_bridge \
-  --mount=type=bind,source=src/universe/external/tier4_ad_api_adaptor,target=/autoware/src/universe/external/tier4_ad_api_adaptor \
   --mount=type=bind,source=src/universe/external/tier4_autoware_msgs,target=/autoware/src/universe/external/tier4_autoware_msgs \
   --mount=type=bind,source=src/middleware/external,target=/autoware/src/middleware/external \
   --mount=type=bind,source=src/launcher,target=/autoware/src/launcher \

--- a/repositories/autoware-nightly.repos
+++ b/repositories/autoware-nightly.repos
@@ -27,10 +27,6 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/managed_transform_buffer.git
     version: main
-  universe/external/tier4_ad_api_adaptor: # TODO(TIER IV): Migrate to AD API and remove this repository entry.
-    type: git
-    url: https://github.com/tier4/tier4_ad_api_adaptor.git
-    version: tier4/universe
   universe/external/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git

--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -37,10 +37,6 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_universe.git
     version: 0.50.0
-  universe/external/tier4_ad_api_adaptor: # TODO(TIER IV): Migrate to AD API and remove this repository entry.
-    type: git
-    url: https://github.com/tier4/tier4_ad_api_adaptor.git
-    version: 0.46.0
   universe/external/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git


### PR DESCRIPTION
## Description

Remove TIER IV API adapter from Dockerfile.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/3096

## How was this PR tested?

CI: docker-build (main)
