### PR TITLE
revert: "feat(autoware.repos): remove tier4 api adapter (#6690)"

### DIFF
--- a/repositories/autoware-nightly.repos
+++ b/repositories/autoware-nightly.repos
@@ -27,6 +27,10 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/managed_transform_buffer.git
     version: main
+  universe/external/tier4_ad_api_adaptor: # TODO(TIER IV): Migrate to AD API and remove this repository entry.
+    type: git
+    url: https://github.com/tier4/tier4_ad_api_adaptor.git
+    version: tier4/universe
   universe/external/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git

--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -37,6 +37,10 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_universe.git
     version: 0.49.0
+  universe/external/tier4_ad_api_adaptor: # TODO(TIER IV): Migrate to AD API and remove this repository entry.
+    type: git
+    url: https://github.com/tier4/tier4_ad_api_adaptor.git
+    version: 0.46.0
   universe/external/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git


### PR DESCRIPTION
## Description

This reverts commit 93c1eed7371412d971b73b873252e18dd7cb473a.

- Reverts: https://github.com/autowarefoundation/autoware/pull/6690
- Required by: https://github.com/autowarefoundation/autoware/pull/6784
- Parent Issue: https://github.com/autowarefoundation/autoware/issues/3096

This was removed without being tested by the CI.

It should be removed with more attention next time.

- Also related: https://github.com/autowarefoundation/autoware/pull/6782

## How was this PR tested?

CI.