### PR TITLE
feat: updates the repository dependencies to support Nebula 0.3.2 and ros2 jazzy

### DIFF
--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -104,10 +104,14 @@ repositories:
     type: git
     url: https://github.com/tier4/sensor_component_description.git
     version: 03ba094851ec90febfcfc0adb20b64b0e19df7a8
+  sensor_component/external/sync_tooling_msgs:
+    type: git
+    url: https://github.com/tier4/sync_tooling_msgs.git
+    version: 0.2.6
   sensor_component/external/nebula:
     type: git
     url: https://github.com/tier4/nebula.git
-    version: v0.2.6
+    version: v0.3.2
   # Fork of transport_drivers that enables reduction of copy operations
   sensor_component/transport_drivers:
     type: git


### PR DESCRIPTION
## Description
This PR updates the repository dependencies to support Nebula 0.3.0 and ROS 2 Jazzy compatibility. It adds the required `sync_tooling_msgs` package and bumps the Nebula version as specified in Issue #6756.

Part of #6756 - Nebula support for Jazzy and other required updates for 0.3.* -- https://github.com/autowarefoundation/autoware/issues/6756
- Task 2: Add sync_tooling_msgs to autoware.repos ✅
- Task 4: Bump nebula version in autoware.repos ✅

parent issue -- https://github.com/autowarefoundation/autoware_universe/issues/11418

## Changes Made

### 1. Added `sync_tooling_msgs` dependency (NEW)

sensor_component/external/sync_tooling_msgs:
  type: git
  url: https://github.com/tier4/sync_tooling_msgs.git
  version: main
### 2. Bumped Nebula version
sensor_component/external/nebula:
  type: git
  url: https://github.com/tier4/nebula.git
  version: v0.3.2  # Previously: v0.2.6

## Dependencies

⚠️ **IMPORTANT: This PR requires updating `autoware_launch` version**

This PR depends on corresponding changes in the `autoware_launch` repository:
- Package dependency updates: `nebula_sensor_driver` → `nebula`
- Launch file updates for Nebula 0.3.0 compatibility

**The `autoware_launch` version in this file must be bumped** (line 101) to a version that includes the Nebula 0.3.2 migration changes. Otherwise, the build will fail due to:
- Missing `nebula` package references (old code still references `nebula_ros`)
- Incorrect decoder package paths (old code uses `nebula_decoders` instead of `nebula_<vendor>_decoders`)
- Missing dependencies in package.xml files

## notes for reviewers

must merged with pr -- https://github.com/autowarefoundation/autoware_launch/pull/1749

## How was this PR tested?
