### PR TITLE
ci: updated vcs import to be recursive

### DIFF
--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -40,7 +40,7 @@ runs:
     - name: Run vcs import
       run: |
         mkdir -p src
-        vcs import --shallow src < repositories/autoware.repos
+        vcs import --recursive --shallow src < repositories/autoware.repos
       shell: bash
 
     - name: Setup Docker Buildx

--- a/.github/actions/docker-build-and-push-tools/action.yaml
+++ b/.github/actions/docker-build-and-push-tools/action.yaml
@@ -29,7 +29,7 @@ runs:
     - name: Run vcs import
       run: |
         mkdir -p src
-        vcs import --shallow src < repositories/simulator.repos
+        vcs import --recursive --shallow src < repositories/simulator.repos
       shell: bash
 
     - name: Setup Docker Buildx

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -42,7 +42,7 @@ runs:
     - name: Run vcs import
       run: |
         mkdir -p src
-        vcs import --shallow src < repositories/autoware.repos
+        vcs import --recursive --shallow src < repositories/autoware.repos
       shell: bash
 
     - name: Setup Docker Buildx

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -32,13 +32,13 @@ runs:
     - name: Run vcs import
       run: |
         mkdir -p src
-        vcs import --shallow src < repositories/autoware.repos
+        vcs import --recursive --shallow src < repositories/autoware.repos
       shell: bash
 
     - name: Import additional repositories
       if: ${{ inputs.additional-repos != '' }}
       run: |
-        vcs import --shallow --force src < ${{ inputs.additional-repos }}
+        vcs import --recursive --shallow --force src < ${{ inputs.additional-repos }}
       shell: bash
 
     - name: Cache ccache

--- a/.github/workflows/scenario-test.yaml
+++ b/.github/workflows/scenario-test.yaml
@@ -40,7 +40,7 @@ jobs:
           git clone https://github.com/autowarefoundation/autoware.git ~/autoware_ws
           cd ~/autoware_ws
           mkdir -p src
-          vcs import src < repositories/simulator.repos
+          vcs import --recursive src < repositories/simulator.repos
       - name: Install ROS dependencies
         shell: bash
         run: |

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,7 +12,7 @@ If you do not need the CUDA drivers, you can also use the smaller image `ghcr.io
 ```shell
 $ git clone git@github.com:autowarefoundation/autoware.git
 $ cd autoware
-$ vcs import src < repositories/autoware.repos
+$ vcs import --recursive src < repositories/autoware.repos
 $ docker run -it --rm \
   –v $PWD/src/universe/autoware_universe/XXX/autoware_YYY:/autoware/src/autoware_YYY \
   ghcr.io/autowarefoundation/autoware:universe-devel-cuda

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -133,10 +133,10 @@ clone_repositories() {
     cd "$WORKSPACE_ROOT"
     if [ ! -d "src" ]; then
         mkdir -p src
-        vcs import src <repositories/autoware.repos
+        vcs import --recursive src <repositories/autoware.repos
     else
         echo "Source directory already exists. Updating repositories..."
-        vcs import src <repositories/autoware.repos
+        vcs import --recursive src <repositories/autoware.repos
         vcs pull src
     fi
 }

--- a/src/README.md
+++ b/src/README.md
@@ -23,7 +23,7 @@ Here is a brief summary of the steps:
 cd autoware
 
 # Clone the Autoware source code into src/
-vcs import src < repositories/autoware.repos
+vcs import --recursive src < repositories/autoware.repos
 ```
 
 This command will clone and check out the correct versions as defined in [`autoware.repos`](../repositories/autoware.repos)


### PR DESCRIPTION
## Description
This PR is a precursor to [autowarefoundation/autoware#6771](https://github.com/autowarefoundation/autoware/pull/6771), where acados is added as a external repository for autoware_universe. The goal is to use acados [https://github.com/autowarefoundation/autoware_universe/pull/11479](https://github.com/autowarefoundation/autoware_universe/pull/11479) to generate MPC code, which will be used as the backend to a MPT path-optimizer update.

Currently, the universe PR above updates the submodules of acados via CMake, but this approach would fail CI as internet access is blocked at the build stage.

Making this change causes the submodules to be downloaded at the vcs import stage, and overcomes the above issue.

## How was this PR tested?
