### PR TITLE
feat: update autoware.repos file for verison 1.7.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -159,6 +159,7 @@ ARG ROS_DISTRO
 
 COPY src/launcher/autoware_launch/tier4_universe_launch/tier4_autoware_api_launch /autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_autoware_api_launch
 COPY src/universe/autoware_universe/system/autoware_default_adapi_universe /autoware/src/universe/autoware_universe/system/autoware_default_adapi_universe
+COPY src/universe/autoware_universe/evaluator/autoware_evaluation_adapter /autoware/src/universe/autoware_universe/evaluator/autoware_evaluation_adapter
 COPY src/core/autoware_core/api/autoware_adapi_adaptors /autoware/src/core/autoware_core/api/autoware_adapi_adaptors
 COPY src/universe/autoware_universe/system/autoware_diagnostic_graph_utils /autoware/src/universe/autoware_universe/system/autoware_diagnostic_graph_utils
 COPY src/core/autoware_core/map/autoware_map_height_fitter /autoware/src/core/autoware_core/map/autoware_map_height_fitter
@@ -528,7 +529,7 @@ RUN find /opt/autoware -type f \( -executable -o -name "*.so" \) -exec strip --s
 RUN --mount=type=cache,target="${CCACHE_DIR}" \
   --mount=type=bind,source=src/sensor_component,target=/autoware/src/sensor_component \
   --mount=type=bind,source=src/universe/autoware_universe/evaluator,target=/autoware/src/universe/autoware_universe/evaluator \
-  --mount=type=bind,source=src/universe/autoware_universe/launch,target=/autoware/src/universe/autoware_universe/launch \
+  --mount=type=bind,source=src/launcher/autoware_launch/tier4_universe_launch,target=/autoware/src/launcher/autoware_launch/tier4_universe_launch \
   --mount=type=bind,source=src/universe/autoware_universe/simulator,target=/autoware/src/universe/autoware_universe/simulator \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && source /opt/autoware/setup.bash \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,8 +68,8 @@ FROM rosdep-depend AS rosdep-universe-sensing-perception-depend
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
-COPY src/universe/autoware_universe/launch/tier4_perception_launch /autoware/src/universe/autoware_universe/launch/tier4_perception_launch
-COPY src/universe/autoware_universe/launch/tier4_sensing_launch /autoware/src/universe/autoware_universe/launch/tier4_sensing_launch
+COPY src/launcher/autoware_launch/tier4_universe_launch/tier4_perception_launch /autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_perception_launch
+COPY src/launcher/autoware_launch/tier4_universe_launch/tier4_sensing_launch /autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_sensing_launch
 COPY src/universe/autoware_universe/perception /autoware/src/universe/autoware_universe/perception
 COPY src/universe/autoware_universe/sensing /autoware/src/universe/autoware_universe/sensing
 COPY src/universe/autoware_universe/evaluator/autoware_perception_online_evaluator /autoware/src/universe/autoware_universe/evaluator/autoware_perception_online_evaluator
@@ -85,8 +85,8 @@ FROM rosdep-depend AS rosdep-universe-localization-mapping-depend
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
-COPY src/universe/autoware_universe/launch/tier4_localization_launch /autoware/src/universe/autoware_universe/launch/tier4_localization_launch
-COPY src/universe/autoware_universe/launch/tier4_map_launch /autoware/src/universe/autoware_universe/launch/tier4_map_launch
+COPY src/launcher/autoware_launch/tier4_universe_launch/tier4_localization_launch /autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_localization_launch
+COPY src/launcher/autoware_launch/tier4_universe_launch/tier4_map_launch /autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_map_launch
 COPY src/universe/autoware_universe/localization /autoware/src/universe/autoware_universe/localization
 COPY src/universe/autoware_universe/map /autoware/src/universe/autoware_universe/map
 # TODO(youtalk): Remove COPYs when https://github.com/autowarefoundation/autoware_universe/issues/10282 is resolved
@@ -104,8 +104,8 @@ FROM rosdep-depend AS rosdep-universe-planning-control-depend
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
-COPY src/universe/autoware_universe/launch/tier4_control_launch /autoware/src/universe/autoware_universe/launch/tier4_control_launch
-COPY src/universe/autoware_universe/launch/tier4_planning_launch /autoware/src/universe/autoware_universe/launch/tier4_planning_launch
+COPY src/launcher/autoware_launch/tier4_universe_launch/tier4_control_launch /autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_control_launch
+COPY src/launcher/autoware_launch/tier4_universe_launch/tier4_planning_launch /autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_planning_launch
 COPY src/universe/autoware_universe/control /autoware/src/universe/autoware_universe/control
 COPY src/universe/autoware_universe/planning /autoware/src/universe/autoware_universe/planning
 # TODO(youtalk): Remove COPYs when https://github.com/autowarefoundation/autoware_universe/issues/8805 is resolved
@@ -133,8 +133,8 @@ FROM rosdep-depend AS rosdep-universe-vehicle-system-depend
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
-COPY src/universe/autoware_universe/launch/tier4_vehicle_launch /autoware/src/universe/autoware_universe/launch/tier4_vehicle_launch
-COPY src/universe/autoware_universe/launch/tier4_system_launch /autoware/src/universe/autoware_universe/launch/tier4_system_launch
+COPY src/launcher/autoware_launch/tier4_universe_launch/tier4_vehicle_launch /autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_vehicle_launch
+COPY src/launcher/autoware_launch/tier4_universe_launch/tier4_system_launch /autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_system_launch
 COPY src/universe/autoware_universe/vehicle /autoware/src/universe/autoware_universe/vehicle
 COPY src/universe/autoware_universe/system /autoware/src/universe/autoware_universe/system
 
@@ -157,7 +157,7 @@ FROM rosdep-depend AS rosdep-universe-api-depend
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
-COPY src/universe/autoware_universe/launch/tier4_autoware_api_launch /autoware/src/universe/autoware_universe/launch/tier4_autoware_api_launch
+COPY src/launcher/autoware_launch/tier4_universe_launch/tier4_autoware_api_launch /autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_autoware_api_launch
 COPY src/universe/autoware_universe/system/autoware_default_adapi_universe /autoware/src/universe/autoware_universe/system/autoware_default_adapi_universe
 COPY src/core/autoware_core/api/autoware_adapi_adaptors /autoware/src/core/autoware_core/api/autoware_adapi_adaptors
 COPY src/universe/autoware_universe/system/autoware_diagnostic_graph_utils /autoware/src/universe/autoware_universe/system/autoware_diagnostic_graph_utils
@@ -309,8 +309,8 @@ RUN --mount=type=ssh \
 
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target="${CCACHE_DIR}" \
-  --mount=type=bind,source=src/universe/autoware_universe/launch/tier4_perception_launch,target=/autoware/src/universe/autoware_universe/launch/tier4_perception_launch \
-  --mount=type=bind,source=src/universe/autoware_universe/launch/tier4_sensing_launch,target=/autoware/src/universe/autoware_universe/launch/tier4_sensing_launch \
+  --mount=type=bind,source=src/launcher/autoware_launch/tier4_universe_launch/tier4_perception_launch,target=/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_perception_launch \
+  --mount=type=bind,source=src/launcher/autoware_launch/tier4_universe_launch/tier4_sensing_launch,target=/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_sensing_launch \
   --mount=type=bind,source=src/universe/external/trt_batched_nms,target=/autoware/src/universe/external/trt_batched_nms \
   --mount=type=bind,source=src/universe/autoware_universe/perception,target=/autoware/src/universe/autoware_universe/perception \
   --mount=type=bind,source=src/universe/autoware_universe/sensing,target=/autoware/src/universe/autoware_universe/sensing \
@@ -369,8 +369,8 @@ RUN --mount=type=ssh \
 
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target="${CCACHE_DIR}" \
-  --mount=type=bind,source=src/universe/autoware_universe/launch/tier4_localization_launch,target=/autoware/src/universe/autoware_universe/launch/tier4_localization_launch \
-  --mount=type=bind,source=src/universe/autoware_universe/launch/tier4_map_launch,target=/autoware/src/universe/autoware_universe/launch/tier4_map_launch \
+  --mount=type=bind,source=src/launcher/autoware_launch/tier4_universe_launch/tier4_localization_launch,target=/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_localization_launch \
+  --mount=type=bind,source=src/launcher/autoware_launch/tier4_universe_launch/tier4_map_launch,target=/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_map_launch \
   --mount=type=bind,source=src/universe/autoware_universe/localization,target=/autoware/src/universe/autoware_universe/localization \
   --mount=type=bind,source=src/universe/autoware_universe/map,target=/autoware/src/universe/autoware_universe/map \
   # TODO(youtalk): Remove COPYs when https://github.com/autowarefoundation/autoware_universe/issues/10282 is resolved
@@ -397,8 +397,8 @@ RUN --mount=type=ssh \
 
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target="${CCACHE_DIR}" \
-  --mount=type=bind,source=src/universe/autoware_universe/launch/tier4_control_launch,target=/autoware/src/universe/autoware_universe/launch/tier4_control_launch \
-  --mount=type=bind,source=src/universe/autoware_universe/launch/tier4_planning_launch,target=/autoware/src/universe/autoware_universe/launch/tier4_planning_launch \
+  --mount=type=bind,source=src/launcher/autoware_launch/tier4_universe_launch/tier4_control_launch,target=/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_control_launch \
+  --mount=type=bind,source=src/launcher/autoware_launch/tier4_universe_launch/tier4_planning_launch,target=/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_planning_launch \
   --mount=type=bind,source=src/universe/autoware_universe/control,target=/autoware/src/universe/autoware_universe/control \
   --mount=type=bind,source=src/universe/autoware_universe/planning,target=/autoware/src/universe/autoware_universe/planning \
   # TODO(youtalk): Remove --mount options when https://github.com/autowarefoundation/autoware_universe/issues/8805 is resolved
@@ -432,8 +432,8 @@ RUN --mount=type=ssh \
 
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target="${CCACHE_DIR}" \
-  --mount=type=bind,source=src/universe/autoware_universe/launch/tier4_vehicle_launch,target=/autoware/src/universe/autoware_universe/launch/tier4_vehicle_launch \
-  --mount=type=bind,source=src/universe/autoware_universe/launch/tier4_system_launch,target=/autoware/src/universe/autoware_universe/launch/tier4_system_launch \
+  --mount=type=bind,source=src/launcher/autoware_launch/tier4_universe_launch/tier4_vehicle_launch,target=/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_vehicle_launch \
+  --mount=type=bind,source=src/launcher/autoware_launch/tier4_universe_launch/tier4_system_launch,target=/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_system_launch \
   --mount=type=bind,source=src/universe/autoware_universe/vehicle,target=/autoware/src/universe/autoware_universe/vehicle \
   --mount=type=bind,source=src/universe/autoware_universe/system,target=/autoware/src/universe/autoware_universe/system \
   --mount=type=bind,source=src/core/autoware_core/map/autoware_map_height_fitter,target=/autoware/src/core/autoware_core/map/autoware_map_height_fitter \
@@ -488,7 +488,7 @@ RUN --mount=type=ssh \
 
 # hadolint ignore=SC1091
 RUN --mount=type=cache,target=${CCACHE_DIR} \
-  --mount=type=bind,source=src/universe/autoware_universe/launch/tier4_autoware_api_launch,target=/autoware/src/universe/autoware_universe/launch/tier4_autoware_api_launch \
+  --mount=type=bind,source=src/launcher/autoware_launch/tier4_universe_launch/tier4_autoware_api_launch,target=/autoware/src/launcher/autoware_launch/tier4_universe_launch/tier4_autoware_api_launch \
   --mount=type=bind,source=src/universe/autoware_universe/system/autoware_default_adapi_universe,target=/autoware/src/universe/autoware_universe/system/autoware_default_adapi_universe \
   --mount=type=bind,source=src/core/autoware_core/api/autoware_adapi_adaptors,target=/autoware/src/core/autoware_core/api/autoware_adapi_adaptors \
   --mount=type=bind,source=src/universe/autoware_universe/system/autoware_diagnostic_graph_utils,target=/autoware/src/universe/autoware_universe/system/autoware_diagnostic_graph_utils \

--- a/repositories/autoware-nightly.repos
+++ b/repositories/autoware-nightly.repos
@@ -39,12 +39,3 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_launch.git
     version: main
-  # TODO(mitsudome-r): remove after https://github.com/autowarefoundation/autoware/pull/6788 is merged
-  sensor_component/external/sync_tooling_msgs:
-    type: git
-    url: https://github.com/tier4/sync_tooling_msgs.git
-    version: 0.2.6
-  sensor_component/external/nebula:
-    type: git
-    url: https://github.com/tier4/nebula.git
-    version: v0.3.2

--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -23,11 +23,11 @@ repositories:
   core/autoware_lanelet2_extension:
     type: git
     url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-    version: 0.10.0
+    version: 0.11.0
   core/autoware_core:
     type: git
     url: https://github.com/autowarefoundation/autoware_core.git
-    version: 1.6.0
+    version: 1.7.0
   core/autoware_rviz_plugins:
     type: git
     url: https://github.com/autowarefoundation/autoware_rviz_plugins.git
@@ -36,7 +36,7 @@ repositories:
   universe/autoware_universe:
     type: git
     url: https://github.com/autowarefoundation/autoware_universe.git
-    version: 0.49.0
+    version: 0.50.0
   universe/external/tier4_ad_api_adaptor: # TODO(TIER IV): Migrate to AD API and remove this repository entry.
     type: git
     url: https://github.com/tier4/tier4_ad_api_adaptor.git
@@ -93,12 +93,12 @@ repositories:
   universe/external/managed_transform_buffer:
     type: git
     url: https://github.com/autowarefoundation/managed_transform_buffer.git
-    version: 0.1.0
+    version: 0.2.0
   # launcher
   launcher/autoware_launch:
     type: git
     url: https://github.com/autowarefoundation/autoware_launch.git
-    version: 0.49.0
+    version: 0.50.0
   # sensor_component
   sensor_component/external/sensor_component_description:
     type: git

--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -107,7 +107,11 @@ repositories:
   sensor_component/external/nebula:
     type: git
     url: https://github.com/tier4/nebula.git
-    version: v0.2.6
+    version: v0.3.2
+  sensor_component/external/sync_tooling_msgs:
+    type: git
+    url: https://github.com/tier4/sync_tooling_msgs.git
+    version: 0.2.6
   # Fork of transport_drivers that enables reduction of copy operations
   sensor_component/transport_drivers:
     type: git

--- a/repositories/tools.repos
+++ b/repositories/tools.repos
@@ -2,4 +2,4 @@ repositories:
   tools:
     type: git
     url: https://github.com/autowarefoundation/autoware_tools.git
-    version: 0.5.0
+    version: 0.6.0


### PR DESCRIPTION
## Description
This updates repositories in autoware.repos file to prepare for 1.7.0
https://github.com/autowarefoundation/autoware/issues/6803

## How was this PR tested?
- [x] Tested build locally on ROS Humble
- [x] Tested planning_simulator
<img width="2813" height="1598" alt="image" src="https://github.com/user-attachments/assets/35726a51-c1ee-4921-8e3a-4ae1ade54958" />

- [ ] Tested logging_simulator
- [ ] Tested AWSIM simulation