### PR TITLE
chore: update nebula to v0.3.2.2

### DIFF
--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -103,7 +103,7 @@ repositories:
   sensor_component/external/nebula:
     type: git
     url: https://github.com/tier4/nebula.git
-    version: v0.3.2
+    version: v0.3.2.2
   sensor_component/external/sync_tooling_msgs:
     type: git
     url: https://github.com/tier4/sync_tooling_msgs.git


### PR DESCRIPTION
## Description
This is a follow up from https://github.com/autowarefoundation/autoware/pull/6812
After updating autoware for 1.7.0, [docker-build-and-push failed for arm environment](https://github.com/autowarefoundation/autoware/actions/runs/22066805678/job/63760691715). 

The error is caused by nebula and this will update autoware.repos file to use the fixed version

## How was this PR tested?
Tested build in CI. 