### PR TITLE
feat(ansible)!: install rust through rustup instead of apt

### DIFF
--- a/ansible/roles/rust/README.md
+++ b/ansible/roles/rust/README.md
@@ -1,11 +1,11 @@
 # rust
 
-This role installs the Rust toolchain (rustc and cargo) via apt for building Autoware components that depend on Rust (e.g. acados and tera_renderer). Rustup is not installed; the system compiler and cargo from the distribution are used.
+This role installs the Rust toolchain (rustc and cargo) via [rustup](https://rustup.rs/) for building Autoware components that depend on Rust (e.g. acados and tera_renderer).
 
 ## Tools
 
-- rustc (apt)
-- cargo (apt)
+- rustc
+- cargo
 
 ## Inputs
 
@@ -15,16 +15,28 @@ This role installs the Rust toolchain (rustc and cargo) via apt for building Aut
 
 ## Manual Installation
 
-```bash
-sudo apt-get update
-sudo apt-get install -y rustc cargo build-essential
+Reference: [Rust installation documentation](https://www.rust-lang.org/tools/install).
 
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o /tmp/rustup-init.sh
+chmod +x /tmp/rustup-init.sh
+
+/tmp/rustup-init.sh -y
+```
+
+Add the following line to your `~/.bashrc`.
+
+```
+. "$HOME/.cargo/env"
+```
+
+And source the file. (`source ~/.bashrc` or just call `bash` in the terminal).
+
+```bash
 # Verify
 cargo --version
 rustc --version
 ```
-
-For a user-managed toolchain (multiple Rust versions, rustup), see [Rust installation documentation](https://www.rust-lang.org/tools/install).
 
 ## Ansible Installation
 

--- a/ansible/roles/rust/README.md
+++ b/ansible/roles/rust/README.md
@@ -26,7 +26,7 @@ chmod +x /tmp/rustup-init.sh
 
 Add the following line to your `~/.bashrc`.
 
-```
+```bash
 . "$HOME/.cargo/env"
 ```
 

--- a/ansible/roles/rust/tasks/main.yaml
+++ b/ansible/roles/rust/tasks/main.yaml
@@ -28,10 +28,20 @@
 - name: Check cargo version
   become: false
   ansible.builtin.shell: |
-    ~/.cargo/bin/cargo --version
+    {{ ansible_env.HOME }}/.cargo/bin/cargo --version
   register: rust_cargo_version
   changed_when: false
 
 - name: Show cargo version
   ansible.builtin.debug:
     msg: "Cargo version: {{ rust_cargo_version.stdout }}"
+
+- name: Check rust version
+  become: false
+  ansible.builtin.command: "{{ ansible_env.HOME }}/.cargo/bin/rustc --version"
+  register: rust_rustc_version
+  changed_when: false
+
+- name: Show rust version
+  ansible.builtin.debug:
+    msg: "Rust version: {{ rust_rustc_version.stdout }}"

--- a/ansible/roles/rust/tasks/main.yaml
+++ b/ansible/roles/rust/tasks/main.yaml
@@ -20,7 +20,7 @@
 
 - name: Source ~/.bashrc to apply PATH
   become: false
-  ansible.builtin.shell: . "{{ ansible_env.HOME }}/.bashrc".bashrc
+  ansible.builtin.shell: . "{{ ansible_env.HOME }}/.bashrc"
   changed_when: false
   args:
     executable: /bin/bash

--- a/ansible/roles/rust/tasks/main.yaml
+++ b/ansible/roles/rust/tasks/main.yaml
@@ -5,7 +5,7 @@
       - curl
     state: present
     update_cache: true
-    
+
 - name: Download rustup-init script
   ansible.builtin.get_url:
     url: https://sh.rustup.rs
@@ -32,7 +32,7 @@
   changed_when: false
   args:
     executable: /bin/bash
-    
+
 - name: Check cargo version
   ansible.builtin.command: cargo --version
   register: rust_cargo_version

--- a/ansible/roles/rust/tasks/main.yaml
+++ b/ansible/roles/rust/tasks/main.yaml
@@ -2,12 +2,37 @@
   become: true
   ansible.builtin.apt:
     name:
-      - rustc
-      - cargo
+      - curl
     state: present
     update_cache: true
-    cache_valid_time: 3600
+    
+- name: Download rustup-init script
+  ansible.builtin.get_url:
+    url: https://sh.rustup.rs
+    dest: /tmp/rustup-init.sh
+    mode: "0755"
 
+- name: Install rustup using rustup-init script
+  become: false
+  ansible.builtin.command: /tmp/rustup-init.sh -y
+  args:
+    creates: "{{ ansible_env.HOME }}/.cargo/bin/rustc"
+
+- name: Ensure ~/.cargo/bin is in PATH via .bashrc
+  become: false
+  ansible.builtin.lineinfile:
+    path: "{{ ansible_env.HOME }}/.bashrc"
+    line: . "$HOME/.cargo/env"
+    insertafter: EOF
+    state: present
+
+- name: Source ~/.bashrc to apply PATH
+  become: false
+  ansible.builtin.shell: . ~/.bashrc
+  changed_when: false
+  args:
+    executable: /bin/bash
+    
 - name: Check cargo version
   ansible.builtin.command: cargo --version
   register: rust_cargo_version

--- a/ansible/roles/rust/tasks/main.yaml
+++ b/ansible/roles/rust/tasks/main.yaml
@@ -19,13 +19,6 @@
     insertafter: EOF
     state: present
 
-- name: Source ~/.bashrc to apply PATH
-  become: false
-  ansible.builtin.shell: . "{{ ansible_env.HOME }}/.bashrc"
-  changed_when: false
-  args:
-    executable: /bin/bash
-
 - name: Check cargo version
   become: false
   ansible.builtin.shell: |

--- a/ansible/roles/rust/tasks/main.yaml
+++ b/ansible/roles/rust/tasks/main.yaml
@@ -1,11 +1,3 @@
-- name: Install Rust toolchain (rustc and cargo) and build dependencies via apt
-  become: true
-  ansible.builtin.apt:
-    name:
-      - curl
-    state: present
-    update_cache: true
-
 - name: Download rustup-init script
   ansible.builtin.get_url:
     url: https://sh.rustup.rs
@@ -28,7 +20,7 @@
 
 - name: Source ~/.bashrc to apply PATH
   become: false
-  ansible.builtin.shell: . ~/.bashrc
+  ansible.builtin.shell: . ansible.builtin.shell: . "{{ ansible_env.HOME }}/.bashrc".bashrc
   changed_when: false
   args:
     executable: /bin/bash

--- a/ansible/roles/rust/tasks/main.yaml
+++ b/ansible/roles/rust/tasks/main.yaml
@@ -1,4 +1,5 @@
 - name: Download rustup-init script
+  become: false
   ansible.builtin.get_url:
     url: https://sh.rustup.rs
     dest: /tmp/rustup-init.sh

--- a/ansible/roles/rust/tasks/main.yaml
+++ b/ansible/roles/rust/tasks/main.yaml
@@ -20,7 +20,7 @@
 
 - name: Source ~/.bashrc to apply PATH
   become: false
-  ansible.builtin.shell: . ansible.builtin.shell: . "{{ ansible_env.HOME }}/.bashrc".bashrc
+  ansible.builtin.shell: . "{{ ansible_env.HOME }}/.bashrc".bashrc
   changed_when: false
   args:
     executable: /bin/bash

--- a/ansible/roles/rust/tasks/main.yaml
+++ b/ansible/roles/rust/tasks/main.yaml
@@ -26,7 +26,9 @@
     executable: /bin/bash
 
 - name: Check cargo version
-  ansible.builtin.command: cargo --version
+  become: false
+  ansible.builtin.shell: |
+    ~/.cargo/bin/cargo --version
   register: rust_cargo_version
   changed_when: false
 


### PR DESCRIPTION
## Description
Previously, apt was used to install rust and cargo, however this results in issues when trying to build tera-renderer, which requires a more recent release than 1.75, which is the version that is installed when the former two are apt installed on a 22.04 system.

[This PR](https://github.com/autowarefoundation/autoware/pull/6771) was merged with the apt change based on [this comment](https://github.com/autowarefoundation/autoware/pull/6771#issuecomment-3912018759) but this proved to be wrong as both local attempts, as well as CI attempts to compile tera-renderer failed.

The following is the failure log from the build, showing this issue.

> Starting >>> autoware_path_optimizer
> --- stderr: autoware_path_optimizer                              
>  Downloading crates ...
> error: failed to download `globset v0.4.18`
> 
> Caused by:
>   unable to get packages from source
> 
> Caused by:
>   failed to download replaced source registry `crates-io`
> 
> Caused by:
>   failed to parse manifest at `/home/arjunram/.cargo/registry/src/index.crates.io-6f17d22bba15001f/globset-0.4.18/Cargo.toml`
> 
> Caused by:
>   feature `edition2024` is required
> 
>   The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.75.0).
>   Consider trying a more recent nightly release.
>   See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
> gmake[2]: *** [src/acados_mpc/CMakeFiles/build_t_renderer.dir/build.make:71: src/acados_mpc/CMakeFiles/build_t_renderer] Error 101
> gmake[1]: *** [CMakeFiles/Makefile2:238: src/acados_mpc/CMakeFiles/build_t_renderer.dir/all] Error 2
> gmake[1]: *** Waiting for unfinished jobs....
> gmake[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
> gmake[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
> gmake: *** [Makefile:146: all] Error 2
> ---
> Failed   <<< autoware_path_optimizer [5.93s, exited with code 2]
> 

This can be solved by installing rust, as it was previously in https://github.com/tier4/autoware_ecu_system_setup/pull/1654/changes before role was removed.
## How was this PR tested?
