### PR TITLE
chore: added streampetr models and directory

### DIFF
--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -73,6 +73,45 @@
     mode: "644"
     checksum: sha256:928f9eb14ac042d725909f12b2be1532c16b09a683485c5936cf04fb04728520
 
+# streampetr
+- name: Create camera_streampetr directory inside {{ data_dir }}
+  ansible.builtin.file:
+    path: "{{ data_dir }}/camera_streampetr"
+    mode: "755"
+    state: directory
+
+- name: Download camera_streampetr/tensorrt_stream_petr.param.yaml
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/streampetr/v1/tensorrt_stream_petr.param.yaml
+    dest: "{{ data_dir }}/camera_streampetr/tensorrt_stream_petr.param.yaml"
+    mode: "644"
+    checksum: sha256:30c6ae13fa0386042324f7cd08c7486bc8170a0b1b381e0da9fc7574b0af6fb9
+
+- name: Download camera_streampetr/simplify_pts_head_memory.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/streampetr/v1/simplify_pts_head_memory.onnx
+    dest: "{{ data_dir }}/camera_streampetr/simplify_pts_head_memory.onnx"
+    mode: "644"
+    checksum: sha256:49b038bd280a1a4ee4f9e244d6e7315eb9c6f7b6f93e27717d9c21cb4d374015
+
+- name: Download camera_streampetr/simplify_position_embedding.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/streampetr/v1/simplify_position_embedding.onnx
+    dest: "{{ data_dir }}/camera_streampetr/simplify_position_embedding.onnx"
+    mode: "644"
+    checksum: sha256:629f14820cb8288659598f6c056c2f6cebe8df3758f1567e74fd1fb3c0f67163
+
+- name: Download camera_streampetr/simplify_extract_img_feat.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/streampetr/v1/simplify_extract_img_feat.onnx
+    dest: "{{ data_dir }}/camera_streampetr/simplify_extract_img_feat.onnx"
+    mode: "644"
+    checksum: sha256:322c2f426f9a01c43d28456f50b33f0fa2039535cf50db7329483097cd363efd
+
 # bevdet
 - name: Create tensorrt_bevdet directory inside {{ data_dir }}
   ansible.builtin.file:


### PR DESCRIPTION
This pull request adds support for deploying the [streampetr ](https://github.com/autowarefoundation/autoware_universe/tree/main/perception/autoware_camera_streampetr) model artifacts by updating the Ansible role responsible for managing model files.

**StreamPetr model deployment automation:**

* Adds tasks to create the `camera_streampetr` directory inside `{{ data_dir }}` with appropriate permissions.
* Automates downloading of four required StreamPetr model files (`tensorrt_stream_petr.param.yaml`, `simplify_pts_head_memory.onnx`, `simplify_position_embedding.onnx`, `simplify_extract_img_feat.onnx`) into the new directory, each with a specified SHA256 checksum for verification.