### PR TITLE
fix(ansible): simplify git-lfs installation

### DIFF
--- a/ansible/roles/dev_tools/tasks/main.yaml
+++ b/ansible/roles/dev_tools/tasks/main.yaml
@@ -3,20 +3,12 @@
   become: true
   ansible.builtin.apt:
     name: git-lfs
-    state: latest
+    state: present
     update_cache: true
 
-# ref: https://github.com/ansible/ansible-lint/issues/1780
-- name: Check if git lfs is installed # https://github.com/git-lfs/git-lfs/issues/901
-  community.general.git_config:
-    list_all: true
-    scope: global
-  register: dev_tools__git_lfs__git_global_config
-
-- name: Setup Git LFS
+- name: Setup Git LFS for current user
   ansible.builtin.command: git lfs install
-  when: "'filter.lfs.required' not in dev_tools__git_lfs__git_global_config.config_values"
-  changed_when: true
+  changed_when: false
 
 - name: Install pipx
   become: true


### PR DESCRIPTION
## Description

Fix Git LFS setup by replacing the `community.general.git_config` check with a direct `git lfs install` call. The `git_config` module now requires a `name` argument even with `list_all: true`, which made it fail the pre-commit ansible lint check.

Since `git lfs install` is idempotent (safely rewrites the same config and hooks every run), the conditional check was unnecessary complexity. Also changed `state: latest` to `state: present` to avoid unintended upgrades on every run.

The error was this (running `pre-commit run -a --config .pre-commit-config-ansible.yaml`):
```
Read https://ansible.readthedocs.io/projects/lint/rules/yaml/ for more details regarding why we have these requirements. Fix mode will not be available.
WARNING  Listing 1 violation(s) that are fatal
args[module]: missing required arguments: name
ansible/roles/dev_tools/tasks/main.yaml:10 Task/Handler: Check if git lfs is installed

Read documentation for instructions on how to ignore specific rule violations.

# Rule Violation Summary

  1 args profile:production tags:syntax,experimental

Failed: 1 failure(s), 0 warning(s) on 275 files. Last profile that met the validation criteria was 'production'. Rating: 5/5 star
```

## How was this PR tested?

Ran the playbook on a fresh machine and on a machine with Git LFS already configured. Verified `git lfs env` shows correct config in both cases. Confirmed ansible-lint passes cleanly.

```bash
pre-commit run -a --config .pre-commit-config-ansible.yaml
```

https://github.com/autowarefoundation/autoware/actions/runs/22242355408/job/64348702771?pr=6834#step:5:96 ✅