### PR TITLE
feat(ansible): add acados role

### DIFF
--- a/ansible/playbooks/openadkit.yaml
+++ b/ansible/playbooks/openadkit.yaml
@@ -30,6 +30,8 @@
       when: module == 'all' and install_devel=='y'
 
     # Module specific dependencies
+    - role: autoware.dev_env.acados
+      when: module == 'all'
     - role: autoware.dev_env.geographiclib
       when: module == 'perception-localization' or module == 'all'
     - role: autoware.dev_env.cuda

--- a/ansible/playbooks/setup_acados.yaml
+++ b/ansible/playbooks/setup_acados.yaml
@@ -1,0 +1,5 @@
+- name: Setup acados
+  hosts: localhost
+  connection: local
+  roles:
+    - role: autoware.dev_env.acados

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -51,6 +51,7 @@
       when: rosdistro == 'humble'
 
     # Autoware module dependencies
+    - role: autoware.dev_env.acados
     - role: autoware.dev_env.geographiclib
     - role: autoware.dev_env.cuda
       when: prompt_install_nvidia == 'y'

--- a/ansible/roles/acados/README.md
+++ b/ansible/roles/acados/README.md
@@ -1,0 +1,88 @@
+# Setup acados
+
+Installs [acados](https://github.com/acados/acados), a fast and embedded solver for nonlinear optimal control, from source.
+
+## What it does
+
+1. Clones the acados repository (shallow) to `/opt/acados`
+2. Initializes submodules (shallow)
+3. Builds and installs acados in-tree with `QPOASES` and position-independent code enabled
+4. Downloads the [tera renderer](https://github.com/acados/tera_renderer) binary to `/opt/acados/bin/t_renderer` (supports `x86_64` and `aarch64`)
+5. Creates a Python virtual environment at `/opt/acados/.venv`
+6. Installs `casadi`, `sympy`, and `acados_template` (editable) in the venv
+7. Adds `CMAKE_PREFIX_PATH`, `ACADOS_SOURCE_DIR`, and `LD_LIBRARY_PATH` to the user's `.bashrc`
+
+## Installation ⭐
+
+Install ansible following the instructions in the [ansible installation guide](../../README.md#ansible-installation).
+
+```bash
+cd ~/autoware # The root directory of the cloned repository
+ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"
+```
+
+This step should be repeated when the ansible directory is updated.
+
+```bash
+ansible-playbook autoware.dev_env.setup_acados --ask-become-pass
+```
+
+## Directory layout
+
+After running, `/opt/acados` contains both the source tree and installed artifacts:
+
+```text
+/opt/acados/
+├── .venv/            # Python virtual environment
+├── bin/t_renderer    # tera renderer binary
+├── build/            # cmake build directory
+├── cmake/            # acadosConfig.cmake (used by find_package)
+├── lib/              # built shared libraries
+├── include/          # headers
+├── interfaces/       # acados_template Python package (installed to .venv)
+├── external/         # submodules (qpoases, etc.)
+└── ...               # remaining source tree
+```
+
+## Usage in CMake
+
+After provisioning, any CMake project can use acados with:
+
+```cmake
+find_package(acados REQUIRED)
+target_link_libraries(your_target PRIVATE acados)
+```
+
+No additional path configuration is needed, `CMAKE_PREFIX_PATH` is set via `.bashrc`.
+
+## Using the Python interface during `colcon build`
+
+If your ROS 2 package generates acados C code at build time (e.g. via a Python script that uses `acados_template` and `casadi`), you need to source the venv so the code-generation script can find the installed packages.
+
+The Ansible role already exports `ACADOS_SOURCE_DIR` and `LD_LIBRARY_PATH` in `.bashrc`, so those are available to `colcon build` as long as you've sourced your shell. The only extra step is pointing CMake at the venv Python so `casadi`, `sympy`, and `acados_template` are importable:
+
+```cmake
+find_program(ACADOS_PYTHON NAMES python3 PATHS $ENV{ACADOS_SOURCE_DIR}/.venv/bin NO_DEFAULT_PATH)
+
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/generated/acados_solver.c
+  COMMAND ${ACADOS_PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_solver.py
+    --output-dir ${CMAKE_CURRENT_BINARY_DIR}/generated
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_solver.py
+  COMMENT "Generating acados solver C code"
+)
+```
+
+The generated C code is then compiled as part of your normal CMake target, no Python dependency at runtime.
+
+## Requirements
+
+- CMake
+- A C compiler (gcc/clang)
+- `make`
+- `git`
+- `python3` with `venv` module (`python3-venv` on Ubuntu)
+
+## Idempotency
+
+The role is safe to run multiple times. The git clone resets any local modifications, and the build steps re-run on each invocation to ensure correctness when the version is changed. The `.bashrc` entries use `lineinfile` with regex matching to avoid duplication. The venv creation is skipped if it already exists (`creates` guard).

--- a/ansible/roles/acados/defaults/main.yaml
+++ b/ansible/roles/acados/defaults/main.yaml
@@ -1,0 +1,5 @@
+acados_version: v0.5.3
+acados_tera_renderer_version: v0.2.0
+acados_pip_packages:
+  - casadi
+  - sympy

--- a/ansible/roles/acados/tasks/main.yaml
+++ b/ansible/roles/acados/tasks/main.yaml
@@ -15,6 +15,7 @@
     state: directory
     mode: "0755"
 
+# cspell:ignore DACADOS
 - name: Configure acados with CMake
   become: true
   ansible.builtin.command:

--- a/ansible/roles/acados/tasks/main.yaml
+++ b/ansible/roles/acados/tasks/main.yaml
@@ -1,0 +1,101 @@
+- name: Clone acados repository (shallow) with submodules
+  become: true
+  ansible.builtin.git:
+    repo: https://github.com/acados/acados.git
+    dest: /opt/acados
+    version: "{{ acados_version }}"
+    depth: 1
+    force: true
+    recursive: true
+
+- name: Create build directory
+  become: true
+  ansible.builtin.file:
+    path: /opt/acados/build
+    state: directory
+    mode: "0755"
+
+- name: Configure acados with CMake
+  become: true
+  ansible.builtin.command:
+    cmd: >
+      cmake
+      -DACADOS_WITH_QPOASES=ON
+      -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+      ..
+    chdir: /opt/acados/build
+  changed_when: false
+
+- name: Build and install acados
+  become: true
+  ansible.builtin.command:
+    cmd: make install -j{{ ansible_processor_vcpus }}
+    chdir: /opt/acados/build
+  changed_when: false
+
+- name: Create acados bin directory
+  become: true
+  ansible.builtin.file:
+    path: /opt/acados/bin
+    state: directory
+    mode: "0755"
+
+- name: Set tera renderer architecture
+  ansible.builtin.set_fact:
+    acados_tera_arch: "{{ {'x86_64': 'amd64', 'aarch64': 'arm64'}[ansible_architecture] }}"
+
+- name: Download tera renderer
+  become: true
+  ansible.builtin.get_url:
+    url: https://github.com/acados/tera_renderer/releases/download/{{ acados_tera_renderer_version }}/t_renderer-{{ acados_tera_renderer_version }}-linux-{{ acados_tera_arch }}
+    dest: /opt/acados/bin/t_renderer
+    mode: "0755"
+
+# ---------- Python virtual environment ----------
+
+- name: Create acados Python virtual environment
+  become: true
+  ansible.builtin.command:
+    cmd: python3 -m venv /opt/acados/.venv
+    creates: /opt/acados/.venv/bin/activate
+
+- name: Upgrade pip inside the virtual environment
+  become: true
+  ansible.builtin.command:
+    cmd: /opt/acados/.venv/bin/pip install --upgrade pip
+  changed_when: false
+
+- name: Install Python packages in acados venv
+  become: true
+  ansible.builtin.command:
+    cmd: /opt/acados/.venv/bin/pip install {{ acados_pip_packages | join(' ') }}
+  changed_when: false
+
+- name: Install acados_template (editable) in acados venv
+  become: true
+  ansible.builtin.command:
+    cmd: /opt/acados/.venv/bin/pip install -e /opt/acados/interfaces/acados_template
+  changed_when: false
+
+# ---------- Environment (.bashrc) ----------
+
+- name: Add acados CMAKE_PREFIX_PATH to .bashrc
+  ansible.builtin.lineinfile:
+    path: "{{ ansible_env.HOME }}/.bashrc"
+    line: export CMAKE_PREFIX_PATH="/opt/acados:${CMAKE_PREFIX_PATH}"
+    regexp: CMAKE_PREFIX_PATH.*acados
+    state: present
+
+- name: Add ACADOS_SOURCE_DIR to .bashrc
+  ansible.builtin.lineinfile:
+    path: "{{ ansible_env.HOME }}/.bashrc"
+    line: export ACADOS_SOURCE_DIR="/opt/acados"
+    regexp: ACADOS_SOURCE_DIR
+    state: present
+
+- name: Add acados LD_LIBRARY_PATH to .bashrc
+  ansible.builtin.lineinfile:
+    path: "{{ ansible_env.HOME }}/.bashrc"
+    line: export LD_LIBRARY_PATH="/opt/acados/lib:${LD_LIBRARY_PATH}"
+    regexp: LD_LIBRARY_PATH.*acados
+    state: present


### PR DESCRIPTION
## Description

- Part of https://github.com/autowarefoundation/autoware/issues/6833

## How was this PR tested?

Follow the instructions in the readme.

```bash
ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"
ansible-playbook autoware.dev_env.setup_acados --ask-become-pass
```

And check out `/opt/acados` directory and `~/.bashrc` file.

Also the CI passes. https://github.com/autowarefoundation/autoware/actions/runs/22257610978?pr=6835 the logs can be checked within these.

## References

- https://docs.acados.org/installation/index.html
- https://docs.acados.org/python_interface/index.html
- https://github.com/acados/tera_renderer/releases/