### PR TITLE
chore: update streampetr v1 model params

### DIFF
--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -110,7 +110,7 @@
     url: https://awf.ml.dev.web.auto/perception/models/streampetr/v1/ml_package_camera_streampetr.param.yaml
     dest: "{{ data_dir }}/camera_streampetr/ml_package_camera_streampetr.param.yaml"
     mode: "644"
-    checksum: sha256:47ca7283260021746e6f5461b8d92817d131e513f64baec65c297cd12477988c
+    checksum: sha256:f539407f0b3aee65f7d6d30401dd0052dfed86fa7beefef86c79061362615218
 
 # bevdet
 - name: Create tensorrt_bevdet directory inside {{ data_dir }}

--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -80,14 +80,6 @@
     mode: "755"
     state: directory
 
-- name: Download camera_streampetr/tensorrt_stream_petr.param.yaml
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/streampetr/v1/tensorrt_stream_petr.param.yaml
-    dest: "{{ data_dir }}/camera_streampetr/tensorrt_stream_petr.param.yaml"
-    mode: "644"
-    checksum: sha256:30c6ae13fa0386042324f7cd08c7486bc8170a0b1b381e0da9fc7574b0af6fb9
-
 - name: Download camera_streampetr/simplify_pts_head_memory.onnx
   become: true
   ansible.builtin.get_url:

--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -112,6 +112,22 @@
     mode: "644"
     checksum: sha256:322c2f426f9a01c43d28456f50b33f0fa2039535cf50db7329483097cd363efd
 
+- name: Download camera_streampetr/ml_package_camera_streampetr.param.yaml
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/streampetr/v1/ml_package_camera_streampetr.param.yaml
+    dest: "{{ data_dir }}/camera_streampetr/ml_package_camera_streampetr.param.yaml"
+    mode: "644"
+    checksum: sha256:47ca7283260021746e6f5461b8d92817d131e513f64baec65c297cd12477988c
+
+- name: Download camera_streampetr/camera_streampetr.param.yaml
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/streampetr/v1/camera_streampetr.param.yaml
+    dest: "{{ data_dir }}/camera_streampetr/camera_streampetr.param.yaml"
+    mode: "644"
+    checksum: sha256:9b1c931ab99f80a713550e63fd25b5e61bedf53961ed0037d51ad7589ae476e0
+
 # bevdet
 - name: Create tensorrt_bevdet directory inside {{ data_dir }}
   ansible.builtin.file:

--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -112,14 +112,6 @@
     mode: "644"
     checksum: sha256:47ca7283260021746e6f5461b8d92817d131e513f64baec65c297cd12477988c
 
-- name: Download camera_streampetr/camera_streampetr.param.yaml
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/streampetr/v1/camera_streampetr.param.yaml
-    dest: "{{ data_dir }}/camera_streampetr/camera_streampetr.param.yaml"
-    mode: "644"
-    checksum: sha256:9b1c931ab99f80a713550e63fd25b5e61bedf53961ed0037d51ad7589ae476e0
-
 # bevdet
 - name: Create tensorrt_bevdet directory inside {{ data_dir }}
   ansible.builtin.file:


### PR DESCRIPTION
# Description
This pull request updates artifacts for [streampetr ](https://github.com/autowarefoundation/autoware_universe/tree/main/perception/autoware_camera_streampetr) by changing the ansible role responsible for managing model files.

This PR adds replaces the model configuration `.yaml` files in a recent PR
https://github.com/autowarefoundation/autoware/pull/6826
Instead of a single param file, we split them into model-specific params [ml_package_camera_streampetr.param.yaml](https://awf.ml.dev.web.auto/perception/models/streampetr/v1/ml_package_camera_streampetr.param.yaml), and params that can be modified on the node [camera_streampetr.param.yaml](https://awf.ml.dev.web.auto/perception/models/streampetr/v1/camera_streampetr.param.yaml).