### PR TITLE
feat: add repos file for autoware_core

### DIFF
--- a/repositories/core.repos
+++ b/repositories/core.repos
@@ -1,0 +1,29 @@
+repositories:
+  autoware_core:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_core.git
+    version: main
+  autoware_cmake:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_cmake.git
+    version: 1.1.0
+  autoware_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_msgs.git
+    version: 1.11.0
+  autoware_internal_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_internal_msgs.git
+    version: 1.12.1
+  autoware_adapi_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
+    version: 1.9.1
+  autoware_utils:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_utils.git
+    version: 1.5.0
+  autoware_lanelet2_extension:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
+    version: 0.12.0


### PR DESCRIPTION
## Description

I noticed that there was a build error in the [Autoware Core source installation guide](https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/core-source-installation/). This is because the Autoware Core source code does not match the ROS buildfarm version.

Therefore, I will change the guide to clone the dependent repository into workspace, just like Autoware Universe.

## How was this PR tested?

Check that the build succeeds with the new guide.
https://github.com/autowarefoundation/autoware-documentation/pull/775