### PR TITLE
fix(ansible/acados): add env vars to /etc/skel/.bashrc too

### DIFF
--- a/ansible/roles/acados/tasks/main.yaml
+++ b/ansible/roles/acados/tasks/main.yaml
@@ -82,21 +82,30 @@
 
 - name: Add acados CMAKE_PREFIX_PATH to .bashrc
   ansible.builtin.lineinfile:
-    path: "{{ ansible_env.HOME }}/.bashrc"
+    path: "{{ item }}"
     line: export CMAKE_PREFIX_PATH="/opt/acados:${CMAKE_PREFIX_PATH}"
     regexp: CMAKE_PREFIX_PATH.*acados
     state: present
+  loop:
+    - "{{ ansible_env.HOME }}/.bashrc"
+    - /etc/skel/.bashrc
 
 - name: Add ACADOS_SOURCE_DIR to .bashrc
   ansible.builtin.lineinfile:
-    path: "{{ ansible_env.HOME }}/.bashrc"
+    path: "{{ item }}"
     line: export ACADOS_SOURCE_DIR="/opt/acados"
     regexp: ACADOS_SOURCE_DIR
     state: present
+  loop:
+    - "{{ ansible_env.HOME }}/.bashrc"
+    - /etc/skel/.bashrc
 
 - name: Add acados LD_LIBRARY_PATH to .bashrc
   ansible.builtin.lineinfile:
-    path: "{{ ansible_env.HOME }}/.bashrc"
+    path: "{{ item }}"
     line: export LD_LIBRARY_PATH="/opt/acados/lib:${LD_LIBRARY_PATH}"
     regexp: LD_LIBRARY_PATH.*acados
     state: present
+  loop:
+    - "{{ ansible_env.HOME }}/.bashrc"
+    - /etc/skel/.bashrc


### PR DESCRIPTION
## Description

Similar to
https://github.com/autowarefoundation/autoware/blob/cd1aa1efd631e9a596f020553bdc56d102ed1e70/ansible/roles/build_tools/tasks/main.yaml#L16-L23

We have to add these env vars to `/etc/skel/.bashrc` as well.

Because the way the current dockerfiles work, a complete new user is created at the `ros_entrypoint.sh` in the docker images.

https://github.com/autowarefoundation/autoware/blob/cd1aa1efd631e9a596f020553bdc56d102ed1e70/docker/etc/ros_entrypoint.sh#L20

So it is either a new user like this (and in the CI) or you load your own user in.

> `/etc/skel/.bashrc` is a template bash configuration file that gets automatically copied to every new user's home directory when their account is created, providing default shell settings, aliases, and environment configurations.

Should resolve this: https://github.com/autowarefoundation/autoware_universe/actions/runs/22376772448/job/64797090378?pr=11479

- Related: https://github.com/autowarefoundation/autoware_universe/pull/11479

## How was this PR tested?
