### PR TITLE
fix(ansible): use dynamic Ubuntu version for CUDA keyring URL

### DIFF
--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -9,6 +9,11 @@
   register: cuda_architecture
   changed_when: false
 
+- name: Get Ubuntu version for CUDA repo
+  ansible.builtin.shell: lsb_release -rs | tr -d '.'
+  register: cuda__ubuntu_version
+  changed_when: false
+
 - name: Remove old /etc/apt/sources.list.d/cuda.list
   become: true
   ansible.builtin.file:
@@ -18,7 +23,7 @@
 - name: Install CUDA keyring
   become: true
   ansible.builtin.apt:
-    deb: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/{{ cuda_architecture.stdout }}/cuda-keyring_1.1-1_all.deb
+    deb: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu{{ cuda__ubuntu_version.stdout }}/{{ cuda_architecture.stdout }}/cuda-keyring_1.1-1_all.deb
     update_cache: true
 
 - name: Get dash-case name of cuda_version


### PR DESCRIPTION
## Description
The CUDA keyring URL was hardcoded to `ubuntu2204`, causing package conflicts when running `setup-dev-env.sh` on Ubuntu 24.04 (Noble).

Specifically, nvidia-firmware from the ubuntu2204 CUDA repo conflicted with nvidia-firmware-590-* from Ubuntu 24.04's native packages, as both owned the same firmware files.

This fix detects the Ubuntu version at runtime via lsb_release and uses the appropriate CUDA repository (e.g., ubuntu2404 on Noble, ubuntu2204 on Jammy).

## How was this PR tested?
Ran `./setup-dev-env.sh --ros-distro jazzy` on Ubuntu 24.04.3 LTS (Noble) and confirmed successful installation without package conflicts.
