### PR TITLE
feat: add jazzy arm docker image build process to current git action

### DIFF
--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -274,12 +274,16 @@ jobs:
     needs: [load-env-jazzy]
     strategy:
       matrix:
-        platform: [amd64]
+        platform: [amd64, arm64]
         include:
           - platform: amd64
             runner: ubuntu-24.04
             arch-platform: linux/amd64
             lib-dir: x86_64
+          - platform: arm64
+            runner: ubuntu-22.04-arm
+            arch-platform: linux/arm64
+            lib-dir: aarch64
     runs-on: ${{ matrix.runner }}
     steps:
       # https://github.com/actions/checkout/issues/211
@@ -344,12 +348,16 @@ jobs:
     needs: [load-env-jazzy, docker-build-and-push-jazzy]
     strategy:
       matrix:
-        platform: [amd64]
+        platform: [amd64, arm64]
         include:
           - platform: amd64
             runner: [self-hosted, Linux, X64]
             arch-platform: linux/amd64
             lib-dir: x86_64
+          - platform: arm64
+            runner: [self-hosted, Linux, ARM64]
+            arch-platform: linux/arm64
+            lib-dir: aarch64
     runs-on: ${{ matrix.runner }}
     steps:
       # https://github.com/actions/checkout/issues/211

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -281,7 +281,7 @@ jobs:
             arch-platform: linux/amd64
             lib-dir: x86_64
           - platform: arm64
-            runner: ubuntu-22.04-arm
+            runner: ubuntu-24.04-arm
             arch-platform: linux/arm64
             lib-dir: aarch64
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
## Description

parent issue -- https://github.com/autowarefoundation/autoware_universe/issues/11418

Enable ARM64 (arm64) Docker image builds for ROS 2 Jazzy so that Jazzy has the same multi-arch coverage as Humble. No new runner types are introduced: both GitHub-hosted and self-hosted ARM64 runners are reused from the existing Humble pipeline.

## Changes

### 1. Jazzy non-CUDA (`docker-build-and-push-jazzy`)

- **Matrix:** `platform: [amd64]` → `platform: [amd64, arm64]`
- **Runner for arm64:** `ubuntu-22.04-arm` (same as Humble non-CUDA arm64)
- Builds and pushes `autoware:*‑jazzy-arm64` in addition to `*‑jazzy-amd64`.  
  `update-docker-manifest-jazzy` already combines them into multi-arch tags (e.g. `universe-jazzy`).

### 2. Jazzy CUDA (`docker-build-and-push-jazzy-cuda`)

- **Matrix:** `platform: [amd64]` → `platform: [amd64, arm64]`
- **Runner for arm64:** `[self-hosted, Linux, ARM64]` (same as Humble CUDA arm64)
- Builds and pushes Jazzy CUDA images for arm64; `update-docker-manifest-jazzy-cuda` merges amd64 and arm64 into multi-arch tags.

## Runner usage

| Runner | Usage |
|--------|--------|
| `ubuntu-22.04-arm` | Jazzy non-CUDA arm64 (reused from Humble) |
| `[self-hosted, Linux, ARM64]` | Jazzy CUDA arm64 (reused from Humble) |

No new runner labels or machines are required. Builds run inside Docker; the container base image (e.g. `autoware-base:latest-jazzy`) defines the OS/ROS version, so using `ubuntu-22.04-arm` for Jazzy is valid.


## How was this PR tested?
- [ ] Both amd64 and arm64 jobs succeed for `docker-build-and-push-jazzy` and `docker-build-and-push-jazzy-cuda` when the corresponding runners are available.