### PR TITLE
ci(dockerfile): bake acados env vars to the images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -250,6 +250,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 ENV CCACHE_DIR="/root/.ccache"
 
+ENV CMAKE_PREFIX_PATH="/opt/acados:${CMAKE_PREFIX_PATH}"
+ENV ACADOS_SOURCE_DIR="/opt/acados"
+ENV LD_LIBRARY_PATH="/opt/acados/lib:${LD_LIBRARY_PATH}"
+
 # Install rosdep dependencies
 COPY --from=rosdep-depend /rosdep-universe-common-depend-packages.txt /tmp/rosdep-universe-common-depend-packages.txt
 # hadolint ignore=SC2002,DL3009


### PR DESCRIPTION
## Description

- https://github.com/autowarefoundation/autoware_universe/pull/11479#issuecomment-3971065468

https://docs.docker.com/reference/dockerfile/#env

> A stage inherits any environment variables that were set using `ENV` by its parent stage or any ancestor. Refer to the [multi-stage builds section](https://docs.docker.com/build/building/multi-stage/) in the manual for more information.

Because of this, we'll bake the env vars directly to the images for universe.

---

I added it  to `universe-common-devel` and the remaining `universe` layers will inherit it.

## How was this PR tested?
