### PR TITLE
feat(clang-tidy): ignore gxx specific warnings at clang-tidy-ci

### DIFF
--- a/.clang-tidy-ci
+++ b/.clang-tidy-ci
@@ -19,4 +19,3 @@ ExtraArgs:
   - -std=c++17
   - -Wno-c11-extensions
   - -Wno-unknown-warning-option
-

--- a/.clang-tidy-ci
+++ b/.clang-tidy-ci
@@ -18,3 +18,5 @@ WarningsAsErrors: "*"
 ExtraArgs:
   - -std=c++17
   - -Wno-c11-extensions
+  - -Wno-unknown-warning-option
+


### PR DESCRIPTION
## Description

Added an extra argument `Wno-unknown-warning-option` to the clang-tidy-ci settings.
It enables us to ignore warnings which is not implemented in clang.

Without the argument, for example, clang-tidy raises an error for `maybe-uninitialized` suppression.
```
error: unknown warning group '-Wmaybe-uninitialized', ignored [clang-diagnostic-unknown-warning-option]
   33 | #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
      |                                ^
```

## How was this PR tested?

 - Tested on my local environment
 - Tested in this [PR](https://github.com/autowarefoundation/autoware_universe/pull/12230) that clang-tidy correctly ignores `maybe-uninitialized` pragma
   - https://github.com/autowarefoundation/autoware_universe/actions/runs/22617329153/job/65534486408?pr=12230