### PR TITLE
feat(artifacts): add diffusion_planner_simplified.onnx to model downloads

### DIFF
--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -538,6 +538,14 @@
     mode: "644"
     checksum: sha256:d726ce7b257ddaf39da8a7dfbd016512e866843c26a9622fdec8a59b45da3e04
 
+- name: Download diffusion_planner/v3.0/diffusion_planner_simplified.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v3.0/diffusion_planner_simplified.onnx
+    dest: "{{ data_dir }}/diffusion_planner/v3.0/diffusion_planner_simplified.onnx"
+    mode: "644"
+    checksum: sha256:a063d323af20d962048315dc0969e4d3cad46e81a20299f39d74a470d58b148b
+
 # tensorrt_vad
 - name: Create tensorrt_vad directory inside {{ data_dir }}
   ansible.builtin.file:

--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -538,13 +538,28 @@
     mode: "644"
     checksum: sha256:d726ce7b257ddaf39da8a7dfbd016512e866843c26a9622fdec8a59b45da3e04
 
-- name: Download diffusion_planner/v3.0/diffusion_planner_simplified.onnx
+- name: Create diffusion_planner/v3.1 directory
+  become: true
+  ansible.builtin.file:
+    path: "{{ data_dir }}/diffusion_planner/v3.1"
+    mode: "755"
+    state: directory
+
+- name: Download diffusion_planner/v3.1/diffusion_planner.onnx
   become: true
   ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v3.0/diffusion_planner_simplified.onnx
-    dest: "{{ data_dir }}/diffusion_planner/v3.0/diffusion_planner_simplified.onnx"
+    url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v3.1/diffusion_planner.onnx
+    dest: "{{ data_dir }}/diffusion_planner/v3.1/diffusion_planner.onnx"
     mode: "644"
     checksum: sha256:a063d323af20d962048315dc0969e4d3cad46e81a20299f39d74a470d58b148b
+
+- name: Download diffusion_planner/v3.1/diffusion_planner.param.json
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/planning/models/diffusion_planner/v3.1/diffusion_planner.param.json
+    dest: "{{ data_dir }}/diffusion_planner/v3.1/diffusion_planner.param.json"
+    mode: "644"
+    checksum: sha256:d726ce7b257ddaf39da8a7dfbd016512e866843c26a9622fdec8a59b45da3e04
 
 # tensorrt_vad
 - name: Create tensorrt_vad directory inside {{ data_dir }}


### PR DESCRIPTION
## Description

Add Ansible task to download the simplified ONNX model for diffusion_planner:

- `diffusion_planner.onnx`

Model is downloaded to `autoware_data/diffusion_planner/v3.1/` directory with SHA256 checksum for verification.

## How was this PR tested?

Model is correctly downloaded and placed.

## Notes for reviewers

None.

## Effects on system behavior

None.