### PR TITLE
ci(pre-commit-ansible): limit ansible-lint to ansible/

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,9 +1,3 @@
-exclude_paths:
-  - src/
-  - build/
-  - install/
-  - log/
-
 skip_list:
   - galaxy # We don't publish to Ansible Galaxy.
   - package-latest # Since this is a development environment, we allow the latest versions.

--- a/.pre-commit-config-ansible.yaml
+++ b/.pre-commit-config-ansible.yaml
@@ -3,5 +3,7 @@ repos:
     rev: v25.8.2
     hooks:
       - id: ansible-lint
+        args:
+          - ansible/
         additional_dependencies:
           - ansible


### PR DESCRIPTION
## Description
`pre-commit-ansible` was checking YAML files outside the `ansible/` directory.

This happened because the `ansible-lint` hook was not explicitly scoped to `ansible/`.

This PR limits the `ansible-lint` target to `ansible/` in `.pre-commit-config-ansible.yaml`.

#6886 intentionally breaks the indentation in docker/docker-compose.yaml to show that pre-commit-ansible incorrectly checks YAML files outside ansible/, so I deleted them.

<img width="962" height="590" alt="image" src="https://github.com/user-attachments/assets/6ba36951-7b58-4c9d-8d13-8ba57b8c69ba" />

Since `ansible-lint` is now explicitly scoped to `ansible/`, the previous `exclude_paths` entries for directories outside `ansible/` are no longer necessary.

## How was this PR tested?

### `pre-commit-ansible` ignores non-Ansible YAML file (docker/docker-compose.yaml) after this change
- #6884
- Confirmed that intentionally broken YAML outside `ansible/` does not fail `pre-commit-ansible`.

<img width="1130" height="629" alt="image" src="https://github.com/user-attachments/assets/98f6fc89-d96a-4f1e-a620-b16bf967d6d7" />


### `pre-commit-ansible` still detects invalid YAML under `ansible/`
- #6885
- Confirmed that intentionally broken YAML under `ansible/` still fails `pre-commit-ansible`.

<img width="1101" height="579" alt="image" src="https://github.com/user-attachments/assets/cfc789c9-d06b-49c4-8f11-cc78de3d0a7a" />