### PR TITLE
chore: update agnocast to v2.3.1

### DIFF
--- a/ansible/roles/agnocast/defaults/main.yaml
+++ b/ansible/roles/agnocast/defaults/main.yaml
@@ -1,3 +1,3 @@
-agnocast_version: 2.3.0
+agnocast_version: 2.3.1
 agnocast_heaphook_package: agnocast-heaphook-v{{ agnocast_version }}
 agnocast_kmod_package: agnocast-kmod-v{{ agnocast_version }}

--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -126,4 +126,4 @@ repositories:
   middleware/external/agnocast:
     type: git
     url: https://github.com/tier4/agnocast.git
-    version: 2.3.0
+    version: 2.3.1


### PR DESCRIPTION
## Description  

Update agnocast to v2.3.1 to fix a rosdep dependency resolution issue.
 
### Background

agnocast v2.3.0 has an incorrect rosdep key (`glog` instead of `libgoogle-glog-dev`) in `package.xml`, which can cause `rosdep install` to fail.

This was fixed in [autowarefoundation/agnocast#1184](https://github.com/autowarefoundation/agnocast/pull/1184).


## How was this PR tested?
Tested by clone build successfully pass.