### PR TITLE
fix(docker-manifests): reorder tags of jazzy cuda images

### DIFF
--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -94,9 +94,9 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
         tags: |
-          type=raw,value=universe-common-devel-cuda${{ inputs.suffix }}-${{ inputs.platform }}
-          type=raw,value=universe-common-devel-cuda-${{ steps.date.outputs.date }}${{ inputs.suffix }}-${{ inputs.platform }}
-          type=ref,event=tag,prefix=universe-common-devel-cuda-,suffix=${{ inputs.suffix }}-${{ inputs.platform }}
+          type=raw,value=universe-common-devel${{ inputs.suffix }}-cuda-${{ inputs.platform }}
+          type=raw,value=universe-common-devel${{ inputs.suffix }}-cuda-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-common-devel${{ inputs.suffix }}-cuda-,suffix=-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-common-devel-cuda
         flavor: |
           latest=false
@@ -107,9 +107,9 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
         tags: |
-          type=raw,value=universe-sensing-perception-devel-cuda${{ inputs.suffix }}-${{ inputs.platform }}
-          type=raw,value=universe-sensing-perception-devel-cuda-${{ steps.date.outputs.date }}${{ inputs.suffix }}-${{ inputs.platform }}
-          type=ref,event=tag,prefix=universe-sensing-perception-devel-cuda-,suffix=${{ inputs.suffix }}-${{ inputs.platform }}
+          type=raw,value=universe-sensing-perception-devel${{ inputs.suffix }}-cuda-${{ inputs.platform }}
+          type=raw,value=universe-sensing-perception-devel${{ inputs.suffix }}-cuda-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-sensing-perception-devel${{ inputs.suffix }}-cuda-,suffix=-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-sensing-perception-devel-cuda
         flavor: |
           latest=false
@@ -120,9 +120,9 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
         tags: |
-          type=raw,value=universe-sensing-perception-cuda${{ inputs.suffix }}-${{ inputs.platform }}
-          type=raw,value=universe-sensing-perception-cuda-${{ steps.date.outputs.date }}${{ inputs.suffix }}-${{ inputs.platform }}
-          type=ref,event=tag,prefix=universe-sensing-perception-cuda-,suffix=${{ inputs.suffix }}-${{ inputs.platform }}
+          type=raw,value=universe-sensing-perception${{ inputs.suffix }}-cuda-${{ inputs.platform }}
+          type=raw,value=universe-sensing-perception${{ inputs.suffix }}-cuda-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-sensing-perception${{ inputs.suffix }}-cuda-,suffix=-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-sensing-perception-cuda
         flavor: |
           latest=false
@@ -133,9 +133,9 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
         tags: |
-          type=raw,value=universe-devel-cuda${{ inputs.suffix }}-${{ inputs.platform }}
-          type=raw,value=universe-devel-cuda-${{ steps.date.outputs.date }}${{ inputs.suffix }}-${{ inputs.platform }}
-          type=ref,event=tag,prefix=universe-devel-cuda-,suffix=${{ inputs.suffix }}-${{ inputs.platform }}
+          type=raw,value=universe-devel${{ inputs.suffix }}-cuda-${{ inputs.platform }}
+          type=raw,value=universe-devel${{ inputs.suffix }}-cuda-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe-devel${{ inputs.suffix }}-cuda-,suffix=-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-devel-cuda
         flavor: |
           latest=false
@@ -146,9 +146,9 @@ runs:
       with:
         images: ghcr.io/${{ github.repository_owner }}/${{ inputs.target-image }}
         tags: |
-          type=raw,value=universe-cuda${{ inputs.suffix }}-${{ inputs.platform }}
-          type=raw,value=universe-cuda-${{ steps.date.outputs.date }}${{ inputs.suffix }}-${{ inputs.platform }}
-          type=ref,event=tag,prefix=universe-cuda-,suffix=${{ inputs.suffix }}-${{ inputs.platform }}
+          type=raw,value=universe${{ inputs.suffix }}-cuda-${{ inputs.platform }}
+          type=raw,value=universe${{ inputs.suffix }}-cuda-${{ steps.date.outputs.date }}-${{ inputs.platform }}
+          type=ref,event=tag,prefix=universe${{ inputs.suffix }}-cuda-,suffix=-${{ inputs.platform }}
         bake-target: docker-metadata-action-universe-cuda
         flavor: |
           latest=false


### PR DESCRIPTION
- Reasoning explained here: https://github.com/autowarefoundation/autoware_universe/pull/12354#issuecomment-4085285623

## Expected change

- **Before**: `universe-devel-cuda-jazzy-amd64`
- **After**: `universe-devel-jazzy-cuda-amd64`

## How was this PR tested?
