### PR TITLE
chore: update autoware_utils version to 1.7.0

### DIFF
--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -19,7 +19,7 @@ repositories:
   core/autoware_utils:
     type: git
     url: https://github.com/autowarefoundation/autoware_utils.git
-    version: 1.6.0
+    version: 1.7.0
   core/autoware_lanelet2_extension:
     type: git
     url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git


### PR DESCRIPTION
## Description
                                                                                                                                                                                                                                                                                                                                                                                                                                         
Update `autoware_utils` from 1.6.0 to 1.7.0.                                                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                                         
  This is required because `autoware_universe` main now uses `BasicPublishedTimePublisher<autoware::agnocast_wrapper::Node>` and `BasicDebugPublisher<autoware::agnocast_wrapper::Node>` in packages like `autoware_shape_estimation`. These template classes were introduced in autoware_utils 1.7.0 ([#96](https://github.com/autowarefoundation/autoware_utils/pull/96),                                                              
  [#97](https://github.com/autowarefoundation/autoware_utils/pull/97)), so the current 1.6.0 causes build failures in `build-and-test-diff-humble-above` CI (e.g., [autoware_core#965](https://github.com/autowarefoundation/autoware_core/pull/965)).                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                                                                                         
  ## Related links                                                                                                                                                                                                                                                                                                                                                                                                                       

  - Build failure: https://github.com/autowarefoundation/autoware_core/actions/runs/23241163330/job/67683470546                                                                                                                                                                                                                                                                                                                          
  - autoware_utils 1.7.0 release: https://github.com/autowarefoundation/autoware_utils/releases/tag/1.7.0


## How was this PR tested?

Built successfully.