### PR TITLE
fix(docker-build-and-push): update `*.repos` to `repositories/*.repos` in jazzy-cuda job

### DIFF
--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -379,7 +379,7 @@ jobs:
         with:
           files: |
             *.env
-            *.repos
+            repositories/*.repos
             .github/actions/combine-multi-arch-images/action.yaml
             .github/actions/docker-build-and-push*/action.yaml
             .github/workflows/docker-build-and-push.yaml


### PR DESCRIPTION
## Summary

- Fix the `docker-build-and-push-jazzy-cuda` job's changed files filter to use `repositories/*.repos` instead of `*.repos`
- This was missed during https://github.com/autowarefoundation/autoware/pull/6761/changes#diff-c48938bfeaf0e15338d8a3d3329d4daee66e2819a6f7542362d0527662f1a05eR374

This makes the build of these images be skipped.
https://github.com/autowarefoundation/autoware/actions/runs/23330508835

<img width="978" height="565" alt="image" src="https://github.com/user-attachments/assets/98543b7a-2c48-497b-9835-97d10d55354c" />

## Test plan

- [x] Verify the `docker-build-and-push-jazzy-cuda` job correctly detects changes to `repositories/*.repos` files