### PR TITLE
refactor(ansible): add version defaults to role defaults

### DIFF
--- a/ansible/playbooks/docker.yaml
+++ b/ansible/playbooks/docker.yaml
@@ -11,7 +11,7 @@
     - name: Print args
       ansible.builtin.debug:
         msg:
-          - cuda_version: "{{ cuda_version }}"
+          - cuda_version: "{{ cuda_version | default('(role default)') }}"
     - name: Show a warning if the NVIDIA libraries will not be installed
       ansible.builtin.pause:
         seconds: 10

--- a/ansible/playbooks/openadkit.yaml
+++ b/ansible/playbooks/openadkit.yaml
@@ -12,9 +12,9 @@
         msg:
           - module: "{{ module }}"
           - rosdistro: "{{ rosdistro }}"
-          - rmw_implementation: "{{ rmw_implementation }}"
-          - cuda_version: "{{ cuda_version }}"
-          - tensorrt_version: "{{ tensorrt_version }}"
+          - rmw_implementation: "{{ rmw_implementation | default('(role default)') }}"
+          - cuda_version: "{{ cuda_version | default('(role default)') }}"
+          - tensorrt_version: "{{ tensorrt_version | default('(role default)') }}"
   roles:
     # Autoware base dependencies
     - role: autoware.dev_env.rmw_implementation

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -27,9 +27,9 @@
       ansible.builtin.debug:
         msg:
           - rosdistro: "{{ rosdistro }}"
-          - rmw_implementation: "{{ rmw_implementation }}"
-          - cuda_version: "{{ cuda_version }}"
-          - tensorrt_version: "{{ tensorrt_version }}"
+          - rmw_implementation: "{{ rmw_implementation | default('(role default)') }}"
+          - cuda_version: "{{ cuda_version | default('(role default)') }}"
+          - tensorrt_version: "{{ tensorrt_version | default('(role default)') }}"
 
     - name: Show a warning if the NVIDIA libraries will not be installed
       ansible.builtin.pause:

--- a/ansible/roles/cuda/defaults/main.yaml
+++ b/ansible/roles/cuda/defaults/main.yaml
@@ -1,1 +1,2 @@
 cuda_install_drivers: true
+cuda_version: "12.8"

--- a/ansible/roles/rmw_implementation/defaults/main.yaml
+++ b/ansible/roles/rmw_implementation/defaults/main.yaml
@@ -1,2 +1,2 @@
-rmw_implementation__rosdistro: null
-rmw_implementation__name: null
+rmw_implementation__rosdistro: "{{ rosdistro | default(lookup('env', 'ROS_DISTRO') | default('jazzy')) }}"
+rmw_implementation__name: rmw_cyclonedds_cpp

--- a/ansible/roles/spconv/defaults/main.yaml
+++ b/ansible/roles/spconv/defaults/main.yaml
@@ -1,1 +1,3 @@
 spconv_is_jetson: false
+spconv_version: 2.3.8
+spconv_cumm_version: 0.5.3

--- a/ansible/roles/tensorrt/defaults/main.yaml
+++ b/ansible/roles/tensorrt/defaults/main.yaml
@@ -1,0 +1,1 @@
+tensorrt_version: "{{ '10.3.0.26-1+cuda12.5' if ansible_architecture == 'aarch64' else '10.8.0.43-1+cuda12.8' }}"


### PR DESCRIPTION
## Summary

Add sensible default values to ansible role `defaults/main.yaml` so that version variables (`cuda_version`, `tensorrt_version`, `spconv_version`, `spconv_cumm_version`, `rmw_implementation`) no longer **need** to be passed externally via `--extra-vars`.

This is the first step toward eliminating the top-level `.env` files (`amd64.env`, `amd64_jazzy.env`, `arm64.env`) and making ansible the single source of truth for version pins.

- Parent issue: #6938

## What changed

### Role defaults added

| Role | Variable | Default |
|---|---|---|
| [`cuda`](https://github.com/autowarefoundation/autoware/blob/e35ce27e5e86db740bf03faf3a134a829991e155/ansible/roles/cuda/defaults/main.yaml) | `cuda_version` | `"12.8"` |
| [`tensorrt`](https://github.com/autowarefoundation/autoware/blob/e35ce27e5e86db740bf03faf3a134a829991e155/ansible/roles/tensorrt/defaults/main.yaml) | `tensorrt_version` | `"10.8.0.43-1+cuda12.8"` (amd64) / `"10.3.0.26-1+cuda12.5"` (arm64 via `ansible_architecture` fact) |
| [`spconv`](https://github.com/autowarefoundation/autoware/blob/e35ce27e5e86db740bf03faf3a134a829991e155/ansible/roles/spconv/defaults/main.yaml) | `spconv_version` | `2.3.8` |
| [`spconv`](https://github.com/autowarefoundation/autoware/blob/e35ce27e5e86db740bf03faf3a134a829991e155/ansible/roles/spconv/defaults/main.yaml) | `spconv_cumm_version` | `0.5.3` |
| [`rmw_implementation`](https://github.com/autowarefoundation/autoware/blob/e35ce27e5e86db740bf03faf3a134a829991e155/ansible/roles/rmw_implementation/defaults/main.yaml) | `rmw_implementation__name` | `rmw_cyclonedds_cpp` |
| [`rmw_implementation`](https://github.com/autowarefoundation/autoware/blob/e35ce27e5e86db740bf03faf3a134a829991e155/ansible/roles/rmw_implementation/defaults/main.yaml) | `rmw_implementation__rosdistro` | Falls back to `ROS_DISTRO` env var, then `"jazzy"` |

### Playbook debug prints

Updated [`openadkit.yaml`](https://github.com/autowarefoundation/autoware/blob/e35ce27e5e86db740bf03faf3a134a829991e155/ansible/playbooks/openadkit.yaml), [`universe.yaml`](https://github.com/autowarefoundation/autoware/blob/e35ce27e5e86db740bf03faf3a134a829991e155/ansible/playbooks/universe.yaml), and [`docker.yaml`](https://github.com/autowarefoundation/autoware/blob/e35ce27e5e86db740bf03faf3a134a829991e155/ansible/playbooks/docker.yaml) debug tasks to use `| default('(role default)')` so they don't fail when variables aren't explicitly passed.

## Why this is safe

**This change is purely additive.** All existing consumers ([`setup-dev-env.sh`](https://github.com/autowarefoundation/autoware/blob/e35ce27e5e86db740bf03faf3a134a829991e155/setup-dev-env.sh), [`docker/build.sh`](https://github.com/autowarefoundation/autoware/blob/e35ce27e5e86db740bf03faf3a134a829991e155/docker/build.sh), CI workflows, [`.webauto-ci`](https://github.com/autowarefoundation/autoware/blob/e35ce27e5e86db740bf03faf3a134a829991e155/.webauto-ci/main/autoware-setup/run.sh)) continue to pass `--extra-vars` from `.env` files. Ansible's variable precedence ensures that `--extra-vars` (priority 22) always override role defaults (priority 2). Behavior is identical.

### Verified consumers

| Consumer | Status | Reason |
|---|---|---|
| `setup-dev-env.sh` | No change | Always passes `--extra-vars` from `.env` files |
| `docker/build.sh` | No change | Uses `setup-dev-env.sh` internally |
| `docker/Dockerfile.base` | No change | Calls `setup-dev-env.sh` with env files COPY'd in |
| `.github/workflows/load-env.yaml` | No change | Parses env files independently of ansible |
| `.webauto-ci/main/autoware-setup/run.sh` | No change | Same `--extra-vars` pattern as `setup-dev-env.sh` |
| Direct `ansible-playbook` calls | Improved | Debug tasks no longer crash on undefined vars |

## What this enables (future PRs)

Once these defaults are in place, consumers can stop passing version variables and let ansible handle them:

```bash
# Before: requires env file sourcing + --extra-vars for every version pin
source amd64.env
ansible-playbook ... --extra-vars cuda_version=12.8 --extra-vars tensorrt_version=10.8.0.43-1+cuda12.8 ...

# After: just pass rosdistro
ansible-playbook ... --extra-vars rosdistro=jazzy
```

The arm64 TensorRT override (`arm64.env`) is replaced by `ansible_architecture` fact detection in the role default — no separate env file needed.

## Test plan

- [ ] Verify `setup-dev-env.sh -y --module base --ros-distro jazzy` still works (env file `--extra-vars` override defaults)
- [ ] Verify `setup-dev-env.sh -y --module base --ros-distro humble` still works
- [ ] Verify Docker image builds pass CI (`docker-build-and-push` workflow)
- [ ] Verify direct ansible call works: `ansible-playbook openadkit.yaml -e module=base -e rosdistro=jazzy` (debug print shows `(role default)` for version vars)

---

- Finishes #6938 (Phase 1)