### PR TITLE
refactor(ansible): rename cumm_version to spconv_cumm_version

### DIFF
--- a/amd64.env
+++ b/amd64.env
@@ -9,5 +9,5 @@ autoware_base_cuda_image=ghcr.io/autowarefoundation/autoware-base:cuda-latest
 
 cuda_version=12.8
 tensorrt_version=10.8.0.43-1+cuda12.8
-cumm_version=0.5.3
+spconv_cumm_version=0.5.3
 spconv_version=2.3.8

--- a/amd64_jazzy.env
+++ b/amd64_jazzy.env
@@ -9,5 +9,5 @@ autoware_base_cuda_image=ghcr.io/autowarefoundation/autoware-base:cuda-latest-ja
 
 cuda_version=12.8
 tensorrt_version=10.8.0.43-1+cuda12.8
-cumm_version=0.5.3
+spconv_cumm_version=0.5.3
 spconv_version=2.3.8

--- a/ansible/roles/spconv/README.md
+++ b/ansible/roles/spconv/README.md
@@ -23,15 +23,15 @@ The following command will install a particular version of the packages using an
 ### Standard installation (amd64 or arm64 server)
 
 ```bash
-export CUMM_VERSION=0.5.3
+export SPCONV_CUMM_VERSION=0.5.3
 export SPCONV_VERSION=2.3.8
-ansible-playbook autoware.dev_env.install_spconv.yaml -e cumm_version=${CUMM_VERSION} -e spconv_version=${SPCONV_VERSION} --ask-become-pass
+ansible-playbook autoware.dev_env.install_spconv.yaml -e spconv_cumm_version=${SPCONV_CUMM_VERSION} -e spconv_version=${SPCONV_VERSION} --ask-become-pass
 ```
 
 ### Installation for NVIDIA Jetson platforms
 
 ```bash
-export CUMM_VERSION=0.5.3
+export SPCONV_CUMM_VERSION=0.5.3
 export SPCONV_VERSION=2.3.8
-ansible-playbook autoware.dev_env.install_spconv.yaml -e cumm_version=${CUMM_VERSION} -e spconv_version=${SPCONV_VERSION} -e spconv_is_jetson=true --ask-become-pass
+ansible-playbook autoware.dev_env.install_spconv.yaml -e spconv_cumm_version=${SPCONV_CUMM_VERSION} -e spconv_version=${SPCONV_VERSION} -e spconv_is_jetson=true --ask-become-pass
 ```

--- a/ansible/roles/spconv/tasks/main.yaml
+++ b/ansible/roles/spconv/tasks/main.yaml
@@ -10,7 +10,7 @@
 - name: Download the cumm package
   ansible.builtin.get_url:
     mode: "0644"
-    url: https://github.com/autowarefoundation/spconv_cpp/releases/download/spconv_v{{ spconv_version }}%2Bcumm_v{{ cumm_version }}%2Bcu128/cumm_{{ cumm_version }}_{{ spconv_normalized_arch }}{{ spconv_arch_suffix }}.deb
+    url: https://github.com/autowarefoundation/spconv_cpp/releases/download/spconv_v{{ spconv_version }}%2Bcumm_v{{ spconv_cumm_version }}%2Bcu128/cumm_{{ spconv_cumm_version }}_{{ spconv_normalized_arch }}{{ spconv_arch_suffix }}.deb
     dest: /tmp/cumm.deb
 
 - name: Install the cumm package
@@ -22,7 +22,7 @@
 - name: Download the spconv package
   ansible.builtin.get_url:
     mode: "0644"
-    url: https://github.com/autowarefoundation/spconv_cpp/releases/download/spconv_v{{ spconv_version }}%2Bcumm_v{{ cumm_version }}%2Bcu128/spconv_{{ spconv_version }}_{{ spconv_normalized_arch }}{{ spconv_arch_suffix }}.deb
+    url: https://github.com/autowarefoundation/spconv_cpp/releases/download/spconv_v{{ spconv_version }}%2Bcumm_v{{ spconv_cumm_version }}%2Bcu128/spconv_{{ spconv_version }}_{{ spconv_normalized_arch }}{{ spconv_arch_suffix }}.deb
     dest: /tmp/spconv.deb
 
 - name: Install the spconv package


### PR DESCRIPTION
## Summary

Rename `cumm_version` to `spconv_cumm_version` to satisfy ansible-lint `var-naming[no-role-prefix]` rule, which requires role variables to be prefixed with the role name.

## Changes

| File | Change |
|---|---|
| [`amd64.env`](https://github.com/autowarefoundation/autoware/blob/b2664da434ba54fda148eaf0516aa12d7d6692df/amd64.env) | `cumm_version=0.5.3` → `spconv_cumm_version=0.5.3` |
| [`amd64_jazzy.env`](https://github.com/autowarefoundation/autoware/blob/b2664da434ba54fda148eaf0516aa12d7d6692df/amd64_jazzy.env) | same |
| [`ansible/roles/spconv/tasks/main.yaml`](https://github.com/autowarefoundation/autoware/blob/b2664da434ba54fda148eaf0516aa12d7d6692df/ansible/roles/spconv/tasks/main.yaml) | `{{ cumm_version }}` → `{{ spconv_cumm_version }}` |
| [`ansible/roles/spconv/README.md`](https://github.com/autowarefoundation/autoware/blob/b2664da434ba54fda148eaf0516aa12d7d6692df/ansible/roles/spconv/README.md) | Updated variable names and export examples |

## Why this is safe

Both [`setup-dev-env.sh`](https://github.com/autowarefoundation/autoware/blob/b2664da434ba54fda148eaf0516aa12d7d6692df/setup-dev-env.sh) and [`.webauto-ci/main/autoware-setup/run.sh`](https://github.com/autowarefoundation/autoware/blob/b2664da434ba54fda148eaf0516aa12d7d6692df/.webauto-ci/main/autoware-setup/run.sh) dynamically extract variable names from the env file via `sed`/`grep` and pass them as `--extra-vars`. Since the key is renamed in the env files and the role tasks simultaneously, the full chain stays consistent:

```
env file (spconv_cumm_version=0.5.3)
  → setup-dev-env.sh extracts key name dynamically
  → --extra-vars spconv_cumm_version=0.5.3
  → ansible role uses {{ spconv_cumm_version }}
```

No consumer hardcodes `cumm_version` by name — all use dynamic extraction from the env file.

## Test plan

- [ ] Verify `pre-commit run --config .pre-commit-config-ansible.yaml --all-files` passes
- [ ] Verify Docker image builds pass CI
- [ ] Verify `setup-dev-env.sh -y --module all --ros-distro jazzy` installs spconv/cumm correctly