### PR TITLE
feat(agnocast): add force install flag for agnocast-kmod

### DIFF
--- a/ansible/roles/agnocast/defaults/main.yaml
+++ b/ansible/roles/agnocast/defaults/main.yaml
@@ -1,3 +1,4 @@
 agnocast_version: 2.3.1
 agnocast_heaphook_package: agnocast-heaphook-v{{ agnocast_version }}
 agnocast_kmod_package: agnocast-kmod-v{{ agnocast_version }}
+agnocast_force_kmod_install: false

--- a/ansible/roles/agnocast/tasks/main.yaml
+++ b/ansible/roles/agnocast/tasks/main.yaml
@@ -139,7 +139,7 @@
   when: agnocast_is_container
 
 - name: Handle kernel-related tasks (headers + kmod, non-container only)
-  when: not agnocast_is_container
+  when: not agnocast_is_container or agnocast_force_kmod_install
   block:
     - name: Check if linux-headers package is available
       ansible.builtin.shell: |


### PR DESCRIPTION
## Description
PR  #6762 introduced a container detection check that skips agnocast-kmod installation inside containers. While this is correct for CI and Docker development environments, it also prevents kmod from  being included in OTA (Over-the-air) installation images, which are built inside containers but need the kernel module.
                                                                                                                                                                                                            
  Changes                                                   
  - Add `agnocast_force_kmod_install` flag (default: false) to the agnocast Ansible role to allow overriding the container detection skip                                                                     

## How was this PR tested?

(ADDED by @sasakisasaki ) We'll see if this required CI succeeds.
- https://github.com/autowarefoundation/autoware/actions/runs/23573703361/job/68641604433?pr=6942
