### PR TITLE
refactor(ansible): remove rmw_implementation_name from playbook vars

### DIFF
--- a/ansible/playbooks/openadkit.yaml
+++ b/ansible/playbooks/openadkit.yaml
@@ -12,7 +12,6 @@
         msg:
           - module: "{{ module }}"
           - rosdistro: "{{ rosdistro }}"
-          - rmw_implementation: "{{ rmw_implementation | default('(role default)') }}"
           - cuda_version: "{{ cuda_version | default('(role default)') }}"
           - tensorrt_version: "{{ tensorrt_version | default('(role default)') }}"
   roles:
@@ -21,7 +20,6 @@
       when: module == 'base'
       vars:
         rmw_implementation__rosdistro: "{{ rosdistro }}"
-        rmw_implementation__name: "{{ rmw_implementation }}"
     - role: autoware.dev_env.gdown
       when: module == 'base'
     - role: autoware.dev_env.kisak_mesa

--- a/ansible/playbooks/role_rmw_implementation.yaml
+++ b/ansible/playbooks/role_rmw_implementation.yaml
@@ -4,4 +4,3 @@
     - role: autoware.dev_env.rmw_implementation
       vars:
         rmw_implementation__rosdistro: "{{ rosdistro }}"
-        rmw_implementation__name: "{{ rmw_implementation }}"

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -27,7 +27,6 @@
       ansible.builtin.debug:
         msg:
           - rosdistro: "{{ rosdistro }}"
-          - rmw_implementation: "{{ rmw_implementation | default('(role default)') }}"
           - cuda_version: "{{ cuda_version | default('(role default)') }}"
           - tensorrt_version: "{{ tensorrt_version | default('(role default)') }}"
 
@@ -44,7 +43,6 @@
     - role: autoware.dev_env.rmw_implementation
       vars:
         rmw_implementation__rosdistro: "{{ rosdistro }}"
-        rmw_implementation__name: "{{ rmw_implementation }}"
     - role: autoware.dev_env.gdown
     - role: autoware.dev_env.build_tools
     - role: autoware.dev_env.agnocast


### PR DESCRIPTION
## Summary
- Remove `rmw_implementation__name` mapping from `vars:` blocks in `universe.yaml`, `openadkit.yaml`, and `role_rmw_implementation.yaml`
- Remove `rmw_implementation` from debug pre_tasks in `universe.yaml` and `openadkit.yaml`
- Keep `rmw_implementation__rosdistro` passthrough intact

---

- The `rmw_implementation` role already defaults `rmw_implementation__name` to `rmw_cyclonedds_cpp` (added in #6939). No caller passes a different value, so the explicit mapping is redundant.

---

- Part of #6938.

## Test plan
- [ ] `setup-dev-env.sh --ros-distro jazzy -y --module all` runs successfully (role picks up default `rmw_cyclonedds_cpp`)
- [ ] `setup-dev-env.sh --ros-distro humble -y --module all` runs successfully