### PR TITLE
refactor: stop sourcing .env files in shell scripts

### DIFF
--- a/.webauto-ci/main/autoware-setup/run.sh
+++ b/.webauto-ci/main/autoware-setup/run.sh
@@ -7,16 +7,7 @@ ansible_args+=("--extra-vars" "data_dir=$HOME/autoware_data")
 ansible_args+=("--extra-vars" "ros2_installation_type=ros-base")
 ansible_args+=("--extra-vars" "install_devel=false")
 
-# read amd64 env file and expand ansible arguments
-source 'amd64.env'
-while read -r env_name; do
-    ansible_args+=("--extra-vars" "${env_name}=${!env_name}")
-done < <(
-    grep -v '^\s*#' amd64.env |
-        grep -v '^\s*$' |
-        sed 's/#.*//' | # remove trailing comments
-        sed 's/=.*//'   # extract variable name
-)
+ansible_args+=("--extra-vars" "rosdistro=humble")
 
 ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"
 ansible-playbook "ansible/playbooks/universe.yaml" \

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -9,20 +9,6 @@ GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-SCRIPT_DIR=$(readlink -f "$(dirname "$0")")
-WORKSPACE_ROOT="$SCRIPT_DIR/.."
-
-# Determine ROS distro from environment or default to humble
-ros_distro=${ROS_DISTRO:-humble}
-if [ "$ros_distro" = "humble" ]; then
-    source "$WORKSPACE_ROOT/amd64.env"
-else
-    source "$WORKSPACE_ROOT/amd64_jazzy.env"
-fi
-if [ "$(uname -m)" = "aarch64" ]; then
-    source "$WORKSPACE_ROOT/arm64.env"
-fi
-
 # Default values
 option_no_nvidia=false
 option_devel=false

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -151,29 +151,10 @@ if [ "$option_module" != "" ]; then
     ansible_args+=("--extra-vars" "module=$option_module")
 fi
 
-# Check ros-distro option
-if [ "$option_ros_distro" != "" ]; then
-    export ROS_DISTRO="$option_ros_distro"
-    ansible_args+=("--extra-vars" "rosdistro=$option_ros_distro")
-fi
-
-# Load env
-source "$SCRIPT_DIR/amd64.env"
-env_file="$SCRIPT_DIR/amd64.env"
-if [ "$option_ros_distro" = "jazzy" ]; then
-    source "$SCRIPT_DIR/amd64_jazzy.env"
-    env_file="$SCRIPT_DIR/amd64_jazzy.env"
-fi
-
-if [ "$(uname -m)" = "aarch64" ]; then
-    source "$SCRIPT_DIR/arm64.env"
-fi
-
-# Add env args
-# shellcheck disable=SC2013
-for env_name in $(sed -e "s/^\s*//" -e "/^#/d" -e "s/=.*//" <"$env_file"); do
-    ansible_args+=("--extra-vars" "${env_name}=${!env_name}")
-done
+# Set ros-distro (default: humble)
+option_ros_distro="${option_ros_distro:-humble}"
+export ROS_DISTRO="$option_ros_distro"
+ansible_args+=("--extra-vars" "rosdistro=$option_ros_distro")
 
 # Install sudo
 if ! (command -v sudo >/dev/null 2>&1); then


### PR DESCRIPTION
## Summary
- `setup-dev-env.sh`: remove `.env` sourcing + sed loop, always pass `rosdistro` (default: `humble`)
- `.webauto-ci/main/autoware-setup/run.sh`: replace `.env` sourcing + grep loop with `--extra-vars rosdistro=humble`
- `docker/run.sh`: remove dead `.env` sourcing (none of the sourced vars were used)

---

- All version pins (`cuda_version`, `tensorrt_version`, `spconv_version`, `spconv_cumm_version`, `rmw_implementation`) now have ansible role defaults added in #6939 / #6940. The `.env` sourcing and extra-vars forwarding in shell scripts is redundant — `rosdistro` is the only config parameter ansible needs from the outside.

---

- Depends on #6947.
- Part of #6938.

## Test plan

### Full validation in Docker

Ubuntu 22.04 (Humble):
```bash
docker run --rm -it ubuntu:22.04 bash -c "apt-get update && apt-get install -y git curl && git clone https://github.com/autowarefoundation/autoware.git -b refactor/stop-sourcing-env-files && cd autoware && ./setup-dev-env.sh -y --no-nvidia --ros-distro humble"
```

Ubuntu 24.04 (Jazzy):
```bash
docker run --rm -it ubuntu:24.04 bash -c "apt-get update && apt-get install -y git curl && git clone https://github.com/autowarefoundation/autoware.git -b refactor/stop-sourcing-env-files && cd autoware && ./setup-dev-env.sh -y --no-nvidia --ros-distro jazzy"
```

### What to look for

- [ ] No errors about missing `.env` files or undefined variables
- [ ] Ansible runs with only `rosdistro=humble` (or `jazzy`) — no version pin extra-vars
- [ ] Roles pick up their own defaults (`cuda_version=12.8`, etc.) from `defaults/main.yaml`
- [ ] Setup completes successfully