### PR TITLE
refactor(docker): derive image names from rosdistro, remove env COPY

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ARG ROS_DISTRO=humble
 FROM $AUTOWARE_BASE_IMAGE AS rosdep-depend
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-COPY setup-dev-env.sh ansible-galaxy-requirements.yaml amd64.env amd64_jazzy.env arm64.env /autoware/
+COPY setup-dev-env.sh ansible-galaxy-requirements.yaml /autoware/
 COPY ansible/ /autoware/ansible/
 COPY docker/scripts/cleanup_apt.sh /autoware/cleanup_apt.sh
 RUN chmod +x /autoware/cleanup_apt.sh

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
 # Copy files
-COPY setup-dev-env.sh ansible-galaxy-requirements.yaml amd64.env amd64_jazzy.env arm64.env /autoware/
+COPY setup-dev-env.sh ansible-galaxy-requirements.yaml /autoware/
 COPY ansible/ /autoware/ansible/
 COPY docker/scripts/cleanup_apt.sh /autoware/cleanup_apt.sh
 RUN chmod +x /autoware/cleanup_apt.sh

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -75,9 +75,6 @@ set_cuda_options() {
     fi
 }
 
-# Note: Image tags are loaded from env files (amd64.env or amd64_jazzy.env)
-# via the load_env() function, which sets $autoware_base_image and $autoware_base_cuda_image
-
 # Set build options
 set_build_options() {
     if [ -n "$option_target" ]; then
@@ -116,16 +113,18 @@ set_arch_lib_dir() {
     fi
 }
 
-# Load env
-load_env() {
+# Derive image names from rosdistro
+derive_images() {
     if [ "$ros_distro" = "humble" ]; then
-        source "$WORKSPACE_ROOT/amd64.env"
+        base_image="ros:humble-ros-base-jammy"
+        autoware_base_image="ghcr.io/autowarefoundation/autoware-base:latest"
+        autoware_base_cuda_image="ghcr.io/autowarefoundation/autoware-base:cuda-latest"
     else
-        source "$WORKSPACE_ROOT/amd64_jazzy.env"
+        base_image="ros:${ros_distro}-ros-base-noble"
+        autoware_base_image="ghcr.io/autowarefoundation/autoware-base:latest-${ros_distro}"
+        autoware_base_cuda_image="ghcr.io/autowarefoundation/autoware-base:cuda-latest-${ros_distro}"
     fi
-    if [ "$platform" = "linux/arm64" ]; then
-        source "$WORKSPACE_ROOT/arm64.env"
-    fi
+    rosdistro="$ros_distro"
 }
 
 # Clone repositories
@@ -206,7 +205,7 @@ set_cuda_options
 set_build_options
 set_platform
 set_arch_lib_dir
-load_env
+derive_images
 clone_repositories
 build_images
 remove_dangling_images


### PR DESCRIPTION
- **Parent Issue:** #6938

## Summary
- Replace `load_env()` in [`docker/build.sh`](https://github.com/autowarefoundation/autoware/blob/fed0ad6d99f427b761338f278cd168aa3d9b540a/docker/build.sh) with `derive_images()` that computes `base_image`, `autoware_base_image`, and `autoware_base_cuda_image` from `ros_distro`
- Remove `amd64.env amd64_jazzy.env arm64.env` from COPY in [`docker/Dockerfile.base`](https://github.com/autowarefoundation/autoware/blob/fed0ad6d99f427b761338f278cd168aa3d9b540a/docker/Dockerfile.base) and [`docker/Dockerfile`](https://github.com/autowarefoundation/autoware/blob/fed0ad6d99f427b761338f278cd168aa3d9b540a/docker/Dockerfile)

## Why
- Image names (`ros:humble-ros-base-jammy`, `ghcr.io/.../autoware-base:latest`, etc.) are fully derivable from `rosdistro` — storing them in `.env` files and sourcing them at build time is unnecessary indirection.
- After #6949, `setup-dev-env.sh` no longer sources `.env` files either, so the Dockerfiles don't need to COPY them into the image.

---

- Depends on #6949

## Test plan

### 1. Verify derived values match .env files

```bash
grep -E 'base_image=|autoware_base_image=|autoware_base_cuda_image=' docker/build.sh amd64.env amd64_jazzy.env
```

- [x] Humble values in `docker/build.sh` match `amd64.env`
- [x] Jazzy values in `docker/build.sh` match `amd64_jazzy.env` (with `${ros_distro}` substituted as `jazzy`)

### 2. Full Docker build test

```bash
docker/build.sh --ros-distro humble --devel-only --no-cuda
```

```bash
docker/build.sh --ros-distro jazzy --devel-only --no-cuda
```

- [x] Both builds complete without errors about missing `.env` files
- [x] Correct base images are used in the build output