### PR TITLE
fix(ci): move GHCR login before buildkit-cache-dance

### DIFF
--- a/.github/actions/docker-build-and-push-cuda/action.yaml
+++ b/.github/actions/docker-build-and-push-cuda/action.yaml
@@ -71,6 +71,13 @@ runs:
           apt-get-${{ inputs.platform }}-main-${{ inputs.platform == 'arm64' && 'arm64-' || '' }}
           apt-get-${{ inputs.platform }}-
 
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ github.token }}
+
     - name: Inject cache into docker
       # TODO(youtalk): Use the release version again
       uses: reproducible-containers/buildkit-cache-dance@7c892679bab8ff382a8c88ab7f973d5e30a8f239
@@ -152,13 +159,6 @@ runs:
         bake-target: docker-metadata-action-universe-cuda
         flavor: |
           latest=false
-
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ github.token }}
 
     - name: Build and Push to GitHub Container Registry
       uses: docker/bake-action@v5

--- a/.github/actions/docker-build-and-push-tools/action.yaml
+++ b/.github/actions/docker-build-and-push-tools/action.yaml
@@ -58,6 +58,13 @@ runs:
         restore-keys: |
           apt-get-tools-${{ inputs.platform }}-
 
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ github.token }}
+
     - name: Inject cache into docker
       # TODO(youtalk): Use the release version again
       uses: reproducible-containers/buildkit-cache-dance@7c892679bab8ff382a8c88ab7f973d5e30a8f239
@@ -100,13 +107,6 @@ runs:
         bake-target: docker-metadata-action-scenario-simulator
         flavor: |
           latest=false
-
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ github.token }}
 
     - name: Build and Push to GitHub Container Registry
       uses: docker/bake-action@v5

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -72,6 +72,13 @@ runs:
           apt-get-${{ inputs.platform }}-main-${{ inputs.platform == 'arm64' && 'arm64-' || '' }}
           apt-get-${{ inputs.platform }}-
 
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ github.token }}
+
     - name: Inject cache into docker
       # TODO(youtalk): Use the release version again
       uses: reproducible-containers/buildkit-cache-dance@7c892679bab8ff382a8c88ab7f973d5e30a8f239
@@ -322,13 +329,6 @@ runs:
         bake-target: docker-metadata-action-universe
         flavor: |
           latest=${{ inputs.set-latest }}
-
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ github.token }}
 
     - name: set build targets
       id: set-build-targets

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -95,6 +95,13 @@ runs:
           apt-get-${{ inputs.platform }}-${{ inputs.cache-tag-suffix }}-
           apt-get-${{ inputs.platform }}-
 
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ github.token }}
+
     - name: Inject cache into docker
       # TODO(youtalk): Use the release version again
       uses: reproducible-containers/buildkit-cache-dance@7c892679bab8ff382a8c88ab7f973d5e30a8f239
@@ -106,13 +113,6 @@ runs:
             "var-cache-apt": "/var/cache/apt"
           }
         skip-extraction: ${{ steps.cache-ccache.outputs.cache-hit && steps.cache-apt-get.outputs.cache-hit }}
-
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ github.token }}
 
     - name: Run docker build
       uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary
- Move `docker/login-action` step before `buildkit-cache-dance` in all 4 docker build composite actions
- The cache-dance action pulls `ghcr.io/containerd/busybox:latest` as a utility image — when unauthenticated, this is subject to GHCR anonymous rate limiting, causing flaky `denied: denied` errors

## Why
The `buildkit-cache-dance` step was running before GHCR login, so the `ghcr.io/containerd/busybox:latest` pull was unauthenticated. GHCR occasionally rejects anonymous OAuth token requests due to rate limiting, causing intermittent CI failures. Authenticating first gives much higher rate limits and eliminates the flakiness.

- Example failure: https://github.com/autowarefoundation/autoware/actions/runs/23653334852/job/68903811247?pr=6950

<img width="1349" height="1103" alt="image" src="https://github.com/user-attachments/assets/b857f7ea-0262-40f4-a791-6753c8ddf44f" />

## Test plan
- [ ] Verify `docker-build-and-push` workflow passes on this PR
- [ ] Monitor subsequent main branch docker builds for absence of `denied: denied` errors