### PR TITLE
refactor(ci): pass rosdistro instead of env files to workflows

### DIFF
--- a/.github/workflows/autoware-base.yaml
+++ b/.github/workflows/autoware-base.yaml
@@ -7,11 +7,9 @@ on:
     paths:
       - .github/actions/docker-build-and-push-base
       - .github/workflows/autoware-base.yaml
-      - amd64.env
       - ansible-galaxy-requirements.yaml
       - ansible/playbooks/openadkit.yaml
       - ansible/roles/**
-      - arm64.env
       - docker/Dockerfile.base
       - docker/etc
       - docker/scripts/cleanup_*.sh
@@ -32,12 +30,10 @@ jobs:
         include:
           - platform: humble
             runner: ubuntu-22.04
-            env-file: amd64.env
             suffix: "" # no suffix for humble since it is default
             set-latest: true
           - platform: jazzy
             runner: ubuntu-24.04
-            env-file: amd64_jazzy.env
             suffix: -jazzy
             set-latest: false
     runs-on: ${{ matrix.runner }}
@@ -53,13 +49,16 @@ jobs:
         with: # cSpell:ignore tonistiigi, binfmt
           image: tonistiigi/binfmt:qemu-v7.0.0
 
-      - name: Load env file
-        id: load-env
-        uses: falti/dotenv-action@v1
-        with:
-          path: ${{ matrix.env-file }}
-          export-variables: true
-          log-variables: true
+      - name: Derive base image from rosdistro
+        id: derive
+        run: |
+          rosdistro="${{ matrix.platform }}"
+          case "${rosdistro}" in
+            humble) echo "base_image=ros:humble-ros-base-jammy" >> "$GITHUB_OUTPUT" ;;
+            jazzy)  echo "base_image=ros:jazzy-ros-base-noble" >> "$GITHUB_OUTPUT" ;;
+            *)      echo "::error::Unknown rosdistro: ${rosdistro}"; exit 1 ;;
+          esac
+        shell: bash
 
       - name: Build Autoware's base images
         uses: ./.github/actions/docker-build-and-push-base
@@ -67,7 +66,7 @@ jobs:
           target-image: autoware-base
           build-args: |
             *.platform=linux/amd64,linux/arm64
-            *.args.ROS_DISTRO=${{ steps.load-env.outputs.rosdistro }}
-            *.args.BASE_IMAGE=${{ steps.load-env.outputs.base_image }}
+            *.args.ROS_DISTRO=${{ matrix.platform }}
+            *.args.BASE_IMAGE=${{ steps.derive.outputs.base_image }}
           suffix: ${{ matrix.suffix }}
           set-latest: ${{ matrix.set-latest }}

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -16,7 +16,7 @@ jobs:
   load-env:
     uses: ./.github/workflows/load-env.yaml
     with:
-      env_file: amd64.env
+      rosdistro: humble
 
   docker-build-and-push:
     needs: load-env
@@ -56,7 +56,6 @@ jobs:
         uses: step-security/changed-files@v46
         with:
           files: |
-            *.env
             repositories/*.repos
             .github/actions/combine-multi-arch-images/action.yaml
             .github/actions/docker-build-and-push*/action.yaml
@@ -127,7 +126,6 @@ jobs:
         uses: step-security/changed-files@v46
         with:
           files: |
-            *.env
             repositories/*.repos
             .github/actions/combine-multi-arch-images/action.yaml
             .github/actions/docker-build-and-push*/action.yaml
@@ -201,7 +199,6 @@ jobs:
         uses: step-security/changed-files@v46
         with:
           files: |
-            *.env
             repositories/*.repos
             .github/actions/combine-multi-arch-images/action.yaml
             .github/actions/docker-build-and-push*/action.yaml
@@ -280,7 +277,7 @@ jobs:
   load-env-jazzy:
     uses: ./.github/workflows/load-env.yaml
     with:
-      env_file: amd64_jazzy.env
+      rosdistro: jazzy
 
   docker-build-and-push-jazzy:
     needs: [load-env-jazzy]
@@ -320,7 +317,6 @@ jobs:
         uses: step-security/changed-files@v46
         with:
           files: |
-            *.env
             repositories/*.repos
             .github/actions/combine-multi-arch-images/action.yaml
             .github/actions/docker-build-and-push*/action.yaml
@@ -398,7 +394,6 @@ jobs:
         uses: step-security/changed-files@v46
         with:
           files: |
-            *.env
             repositories/*.repos
             .github/actions/combine-multi-arch-images/action.yaml
             .github/actions/docker-build-and-push*/action.yaml

--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -70,7 +70,6 @@ jobs:
         uses: step-security/changed-files@v46
         with:
           files: |
-            *.env
             repositories/*.repos
             .github/actions/docker-build/action.yaml
             .github/workflows/health-check.yaml

--- a/.github/workflows/load-env.yaml
+++ b/.github/workflows/load-env.yaml
@@ -3,11 +3,11 @@ name: load-env
 on:
   workflow_call:
     inputs:
-      env_file:
-        description: Specify the env file to load (e.g., amd64.env, amd64_jazzy.env)
+      rosdistro:
+        description: ROS distribution name (humble or jazzy)
         required: false
         type: string
-        default: ""
+        default: humble
     outputs:
       rosdistro:
         value: ${{ jobs.load-env.outputs.rosdistro }}
@@ -22,46 +22,31 @@ jobs:
   load-env:
     runs-on: ubuntu-22.04
     outputs:
-      rosdistro: ${{ steps.set-env.outputs.rosdistro }}
-      base_image: ${{ steps.set-env.outputs.base_image }}
-      autoware_base_image: ${{ steps.set-env.outputs.autoware_base_image }}
-      autoware_base_cuda_image: ${{ steps.set-env.outputs.autoware_base_cuda_image }}
+      rosdistro: ${{ steps.derive.outputs.rosdistro }}
+      base_image: ${{ steps.derive.outputs.base_image }}
+      autoware_base_image: ${{ steps.derive.outputs.autoware_base_image }}
+      autoware_base_cuda_image: ${{ steps.derive.outputs.autoware_base_cuda_image }}
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Load env
+      - name: Derive image names from rosdistro
+        id: derive
         run: |
-          # Check if env_file is specified
-          if [ -n "${{ inputs.env_file }}" ]; then
-            # Use specified env file
-            echo "Loading specified env file: ${{ inputs.env_file }}"
-            cat ${{ inputs.env_file }} | sed -e "s/^\s*//" -e "/^#/d" >> $GITHUB_ENV
-          else
-            # Auto-detect based on ROS_DISTRO
-            rosdistro=${ROS_DISTRO:-humble}
-            echo "rosdistro=$rosdistro" >> $GITHUB_ENV
+          rosdistro="${{ inputs.rosdistro }}"
+          echo "rosdistro=${rosdistro}" >> "$GITHUB_OUTPUT"
 
-            # Determine which env file to use based on rosdistro
-            if [ "$rosdistro" = "humble" ]; then
-              echo "Loading amd64.env for Humble"
-              cat amd64.env | sed -e "s/^\s*//" -e "/^#/d" >> $GITHUB_ENV
-            else
-              echo "Loading amd64_jazzy.env for Jazzy"
-              cat amd64_jazzy.env | sed -e "s/^\s*//" -e "/^#/d" >> $GITHUB_ENV
-            fi
-          fi
-
-          # Load ARM64 specific env if on ARM64 architecture
-          if [ "$(uname -m)" = "aarch64" ]; then
-            echo "Loading arm64.env for ARM64 architecture"
-            cat arm64.env | sed -e "s/^\s*//" -e "/^#/d" >> $GITHUB_ENV
-          fi
-
-      - name: Set env
-        id: set-env
-        run: |
-          echo "rosdistro=${{ env.rosdistro }}" >> $GITHUB_OUTPUT
-          echo "base_image=${{ env.base_image }}" >> $GITHUB_OUTPUT
-          echo "autoware_base_image=${{ env.autoware_base_image }}" >> $GITHUB_OUTPUT
-          echo "autoware_base_cuda_image=${{ env.autoware_base_cuda_image }}" >> $GITHUB_OUTPUT
+          case "${rosdistro}" in
+            humble)
+              echo "base_image=ros:humble-ros-base-jammy" >> "$GITHUB_OUTPUT"
+              echo "autoware_base_image=ghcr.io/autowarefoundation/autoware-base:latest" >> "$GITHUB_OUTPUT"
+              echo "autoware_base_cuda_image=ghcr.io/autowarefoundation/autoware-base:cuda-latest" >> "$GITHUB_OUTPUT"
+              ;;
+            jazzy)
+              echo "base_image=ros:jazzy-ros-base-noble" >> "$GITHUB_OUTPUT"
+              echo "autoware_base_image=ghcr.io/autowarefoundation/autoware-base:latest-jazzy" >> "$GITHUB_OUTPUT"
+              echo "autoware_base_cuda_image=ghcr.io/autowarefoundation/autoware-base:cuda-latest-jazzy" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Unknown rosdistro: ${rosdistro}"
+              exit 1
+              ;;
+          esac
+        shell: bash


### PR DESCRIPTION
- **Parent Issue:** #6938

## Summary
- Replace env file parsing in CI workflows with rosdistro-based image derivation
- [`load-env.yaml`](https://github.com/autowarefoundation/autoware/blob/26a75fa17e3ab22e968072d65e32564b8ac3f8a7/.github/workflows/load-env.yaml) now accepts a `rosdistro` input and derives `base_image`, `autoware_base_image`, and `autoware_base_cuda_image` via a case statement — no checkout or file parsing needed
- [`autoware-base.yaml`](https://github.com/autowarefoundation/autoware/blob/26a75fa17e3ab22e968072d65e32564b8ac3f8a7/.github/workflows/autoware-base.yaml) drops `falti/dotenv-action` in favor of inline derivation
- Remove `*.env` from changed-files path filters in all workflows

## Why
This is step 2d of eliminating `.env` files (#6938). The env files are now redundant — all version pins live in ansible role defaults, and Docker image names are derivable from `rosdistro`. This removes the last CI consumers of `.env` files, unblocking their deletion.

---

- Depends on #6950 (docker: derive image names from rosdistro)
- Depends on #6949 (shell scripts: stop sourcing .env files)

## Test plan
- [ ] `docker-build-and-push` workflow runs successfully on this PR — verify humble and jazzy jobs both receive correct `ROS_DISTRO`, `BASE_IMAGE`, `AUTOWARE_BASE_IMAGE`, and `AUTOWARE_BASE_CUDA_IMAGE` values
   - **1st run:** ❌ https://github.com/autowarefoundation/autoware/actions/runs/23665732501
      - 🔨 https://github.com/autowarefoundation/autoware/pull/6954
   - **2nd run:** ❌ https://github.com/autowarefoundation/autoware/actions/runs/23669459245
      - 🔨 https://github.com/autowarefoundation/autoware/pull/6960
   - I won't run it the 3rd time since it is tested enough. The failures are known flakes and are being addressed.
- [x] `health-check` workflow is not triggered by `.env` file changes
- [x] Verify no workflow references `.env` files:
  ```
  grep -r '\.env' .github/workflows/ --include='*.yaml' | grep -v node_modules
  ```
- [x] health-check also utilizes load-env: https://github.com/autowarefoundation/autoware/actions/runs/23665571500/workflow?pr=6952#L24-L29