### PR TITLE
fix(ci): add swap and limit CPU cores to prevent arm64 runner OOM

### DIFF
--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -89,6 +89,35 @@ jobs:
           matrix.build-type != 'main' }}
         uses: ./.github/actions/free-disk-space
 
+      - name: Show runner info
+        run: |
+          echo "::group::CPU"
+          nproc
+          lscpu
+          echo "::endgroup::"
+          echo "::group::Memory"
+          free -h
+          echo "::endgroup::"
+          echo "::group::Swap"
+          swapon --show
+          echo "::endgroup::"
+          echo "::group::Disk"
+          df -h
+          echo "::endgroup::"
+
+      - name: Create additional swap
+        if: ${{ matrix.platform == 'arm64' &&
+          (steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch') }}
+        run: |
+          sudo fallocate -l 8G /mnt/swapfile
+          sudo chmod 600 /mnt/swapfile
+          sudo mkswap /mnt/swapfile
+          sudo swapon /mnt/swapfile
+          free -h
+          swapon --show
+
       - name: Build 'Autoware'
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'schedule' ||

--- a/docker/scripts/build_and_clean.sh
+++ b/docker/scripts/build_and_clean.sh
@@ -6,9 +6,17 @@ function build_and_clean() {
     local install_base=$2
     local colcon_build_args=$3
 
+    # Limit CPU cores to (nproc - 1) to prevent OOM on resource-constrained runners
+    local taskset_cmd=""
+    local num_cores
+    num_cores=$(nproc)
+    if [ "$num_cores" -gt 1 ]; then
+        taskset_cmd="taskset --cpu-list 0-$((num_cores - 2))"
+    fi
+
     # shellcheck disable=SC2086
     du -sh "$ccache_dir" && ccache -s &&
-        colcon build --cmake-args \
+        $taskset_cmd colcon build --cmake-args \
             " -Wno-dev" \
             " --no-warn-unused-cli" \
             --merge-install \


### PR DESCRIPTION
- **Closes:** #6956

## Changes

1. **Add 8 GB swapfile for arm64 health-check builds** -- the arm64 runner (4 vCPU / 16 GB RAM) intermittently OOM-kills during heavy C++ compilation. Adding swap increases virtual memory from ~18 GB to ~26 GB, providing headroom for transient memory spikes.

2. **Use `taskset` to restrict `colcon build` to `nproc - 1` cores** -- reserves one core for OS/Docker/BuildKit overhead. Under taskset, `nproc` returns 3, so colcon builds 3 packages in parallel instead of 4.

3. **Print runner info (CPU, memory, swap, disk)** before the build for easier debugging.

## Why

The `docker-build (main-arm64)` job intermittently fails because `colcon build` defaults to using all available cores. With multiple packages compiling in parallel, each spawning multiple cmake compile jobs, the runner exceeds its memory budget and loses communication with the server.

`taskset` alone was insufficient (see #6956 comment) because it only limits CPU affinity, not memory. 9 concurrent compiler processes (3 packages x 3 jobs) can still exceed 16 GB. The additional swap provides the extra headroom needed.

If this is still not enough, the next step is `CMAKE_BUILD_PARALLEL_LEVEL` to directly limit per-package compile jobs.

## Test plan

- [ ] Verify `docker-build (main-arm64)` health-check job passes without runner communication loss
- [ ] Verify other matrix entries (main, nightly) are unaffected
- [x] Verify runner info step prints CPU/memory/swap/disk stats