### PR TITLE
feat(repositories/autoware.repos): add autoware_system_designer v0.3.1 and fix Docker rosdep

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,7 @@ COPY src/core/autoware_cmake /autoware/src/core/autoware_cmake
 COPY src/core/autoware_internal_msgs /autoware/src/core/autoware_internal_msgs
 COPY src/core/autoware_lanelet2_extension /autoware/src/core/autoware_lanelet2_extension
 COPY src/core/autoware_msgs /autoware/src/core/autoware_msgs
+COPY src/core/autoware_system_designer /autoware/src/core/autoware_system_designer
 COPY src/core/autoware_utils /autoware/src/core/autoware_utils
 RUN rosdep update && /autoware/resolve_rosdep_keys.sh /autoware/src "${ROS_DISTRO}" \
   > /rosdep-core-common-depend-packages.txt \
@@ -222,6 +223,7 @@ RUN --mount=type=cache,target="${CCACHE_DIR}" \
   --mount=type=bind,source=src/core/autoware_internal_msgs,target=/autoware/src/core/autoware_internal_msgs \
   --mount=type=bind,source=src/core/autoware_lanelet2_extension,target=/autoware/src/core/autoware_lanelet2_extension \
   --mount=type=bind,source=src/core/autoware_msgs,target=/autoware/src/core/autoware_msgs \
+  --mount=type=bind,source=src/core/autoware_system_designer,target=/autoware/src/core/autoware_system_designer \
   --mount=type=bind,source=src/core/autoware_utils,target=/autoware/src/core/autoware_utils \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \
   && /autoware/build_and_clean.sh "${CCACHE_DIR}" /opt/autoware

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -278,6 +278,7 @@ RUN --mount=type=cache,target="${CCACHE_DIR}" \
   --mount=type=bind,source=src/universe/external/pointcloud_to_laserscan,target=/autoware/src/universe/external/pointcloud_to_laserscan \
   --mount=type=bind,source=src/universe/external/rtklib_ros_bridge,target=/autoware/src/universe/external/rtklib_ros_bridge \
   --mount=type=bind,source=src/universe/external/tier4_autoware_msgs,target=/autoware/src/universe/external/tier4_autoware_msgs \
+  --mount=type=bind,source=src/core/autoware_system_designer,target=/autoware/src/core/autoware_system_designer \
   --mount=type=bind,source=src/middleware/external,target=/autoware/src/middleware/external \
   --mount=type=bind,source=src/launcher,target=/autoware/src/launcher \
   source /opt/ros/"$ROS_DISTRO"/setup.bash \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -175,6 +175,7 @@ FROM rosdep-depend AS rosdep-universe-depend
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ROS_DISTRO
 
+COPY src/core /autoware/src/core
 COPY src/launcher /autoware/src/launcher
 COPY src/sensor_component /autoware/src/sensor_component
 COPY src/universe /autoware/src/universe

--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -32,6 +32,10 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_rviz_plugins.git
     version: 0.4.0
+  core/autoware_system_designer:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_system_designer.git
+    version: v0.3.1
   # universe
   universe/autoware_universe:
     type: git


### PR DESCRIPTION
- **Related:** #6739
- Add `autoware_system_designer` to [`repositories/autoware.repos`](https://github.com/autowarefoundation/autoware/blob/e5fcb16c46e5fd564b9473acc04313bb22196a68/repositories/autoware.repos) at version `v0.3.1`
- Fix `rosdep-universe-depend` Docker stage to include `src/core`

## Why

The system designer was only present in `autoware-nightly.repos`, which means pinned builds did not include it. As noted in #6739, every repo should have a pinned entry in `autoware.repos` with the nightly variant acting as an overlay.

The `rosdep-universe-depend` stage in the Dockerfile was missing `COPY src/core`, so `resolve_rosdep_keys.sh` could not identify core packages (like `autoware_system_designer`) as local workspace packages and failed with `ERROR: no rosdep rule for 'autoware_system_designer'`:
- [CI failure](https://github.com/autowarefoundation/autoware/actions/runs/24238221304/job/70766076243?pr=6958#step:12:4263)

This was not an issue before because all core packages that universe depended on were released to the ROS index, so rosdep could resolve them without needing the source. `autoware_system_designer` is the first core package that is only available as a source build and not in the rosdep index, which exposed the missing `COPY src/core`.

---

- Depends on #6739

## Test plan

- [x] Verify the repos entry is valid:
  ```bash
  vcs validate < repositories/autoware.repos
  ```
- [x] Confirm the tag exists:
  ```bash
  git ls-remote --tags https://github.com/autowarefoundation/autoware_system_designer.git v0.3.1
  ```
- [ ] Docker health check CI passes (the `rosdep-universe-depend` stage should no longer fail)