### PR TITLE
fix(ansible): increase get_url timeout and update yabloc model URL

### DIFF
--- a/ansible/playbooks/download_artifacts.yaml
+++ b/ansible/playbooks/download_artifacts.yaml
@@ -1,4 +1,7 @@
 - name: Download Autoware artifacts
   hosts: localhost
+  module_defaults:
+    ansible.builtin.get_url:
+      timeout: 300
   roles:
     - autoware.dev_env.artifacts

--- a/ansible/playbooks/openadkit.yaml
+++ b/ansible/playbooks/openadkit.yaml
@@ -1,6 +1,9 @@
 - name: Set up source development environments for Autoware Universe
   hosts: localhost
   connection: local
+  module_defaults:
+    ansible.builtin.get_url:
+      timeout: 300
   pre_tasks:
     - name: Verify OS
       ansible.builtin.fail:

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -1,6 +1,9 @@
 - name: Set up source development environments for Autoware Universe
   hosts: localhost
   connection: local
+  module_defaults:
+    ansible.builtin.get_url:
+      timeout: 300
   vars_prompt:
     - name: prompt_install_nvidia
       prompt: |-

--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -8,7 +8,7 @@
 - name: Download yabloc_pose_initializer/resources.tar.gz
   become: true
   ansible.builtin.get_url:
-    url: https://s3.ap-northeast-2.wasabisys.com/pinto-model-zoo/136_road-segmentation-adas-0001/resources.tar.gz
+    url: https://autoware-files.s3.us-west-2.amazonaws.com/models/yabloc/136_road-segmentation-adas-0001/resources.tar.gz
     dest: "{{ data_dir }}/yabloc_pose_initializer/resources.tar.gz"
     mode: "644"
     checksum: sha256:1f660e15f95074bade32b1f80dbf618e9cee1f0b9f76d3f4671cb9be7f56eb3a


### PR DESCRIPTION
- **Parent Issue:** #7001
- Increase the `ansible.builtin.get_url` socket timeout from the default 10s to 300s across all playbooks that download artifacts
- Update yabloc_pose_initializer model URL from wasabisys to autoware-files S3

## Why

The `setup-universe` CI frequently fails with `TimeoutError: The read operation timed out` when downloading ML model artifacts from external servers. The default 10-second socket timeout is too tight for CI runners with variable network performance. Setting `module_defaults` at the play level fixes all download tasks without modifying each one individually.

The yabloc model URL is also updated to point to the canonical Autoware S3 bucket.

## Test plan

- [x] Re-run the failing `setup-universe` CI job and confirm it passes the artifact download step