### PR TITLE
feat(docker): add new Dockerfiles, HCL bake config, and ansible playbook

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -3,3 +3,5 @@ ignored:
   - DL3013 # Pin versions in pip. Instead of `pip install <package>`, use `pip install <package>==<version>`
   - DL3015 # Avoid additional packages by specifying `--no-install-recommends`
   - DL3009 # Delete the apt-get lists after installing something
+  - DL3002 # Last USER should not be root (multi-stage builds need root in intermediate stages)
+  - DL3004 # Do not use sudo (our images use passwordless sudo by design)

--- a/ansible/playbooks/autoware_requirements.yaml
+++ b/ansible/playbooks/autoware_requirements.yaml
@@ -1,0 +1,45 @@
+- name: Autoware development environment
+  hosts: localhost
+  connection: local
+  vars:
+    rosdistro:
+  pre_tasks:
+    - name: Print configuration
+      ansible.builtin.debug:
+        msg:
+          - rosdistro: "{{ rosdistro }}"
+      tags: [always]
+
+  roles:
+    - role: autoware.dev_env.rmw_implementation
+      tags: [base, core, universe, rmw]
+
+    - role: autoware.dev_env.build_tools
+      tags: [core, universe, ccache]
+
+    - role: autoware.dev_env.dev_tools
+      tags: [core, universe, dev_tools]
+
+    - role: autoware.dev_env.ros2_dev_tools
+      tags: [core, universe, ros2_dev_tools]
+
+    - role: autoware.dev_env.acados
+      tags: [universe, acados]
+
+    - role: autoware.dev_env.geographiclib
+      tags: [universe, geographiclib]
+
+    - role: autoware.dev_env.qt5ct_setup
+      tags: [universe, qt5ct_setup]
+
+    - role: autoware.dev_env.cuda
+      tags: [universe, nvidia, cuda]
+
+    - role: autoware.dev_env.tensorrt
+      tags: [universe, nvidia, tensorrt]
+
+    - role: autoware.dev_env.spconv
+      tags: [universe, nvidia, spconv]
+
+    - role: autoware.dev_env.artifacts
+      tags: [universe, artifacts]

--- a/docker-new/README.md
+++ b/docker-new/README.md
@@ -1,0 +1,127 @@
+# Run Autoware in Docker
+
+## Image Graph
+
+```mermaid
+graph TD
+    base(["base"])
+    base --> core-dependencies(["core-dependencies"])
+    core-dependencies --> core-devel(["core-devel"])
+    core-devel --> universe-dependencies(["universe-dependencies"])
+    universe-dependencies --> universe-dependencies-cuda(["universe-dependencies-cuda"])
+    universe-dependencies --> universe-devel(["universe-devel"])
+    universe-dependencies-cuda --> universe-devel-cuda(["universe-devel-cuda"])
+    base --> core(["core"])
+    core-devel -- " COPY /opt/autoware " --> core
+    core --> universe-runtime-dependencies(["universe-runtime-dependencies"])
+    universe-runtime-dependencies --> universe(["universe"])
+    universe-runtime-dependencies --> universe-cuda(["universe-cuda"])
+    universe-devel -- " COPY /opt/autoware " --> universe
+    universe-devel-cuda -- " COPY /opt/autoware " --> universe-cuda
+    classDef base fill: #e8e8e8, color: #333
+    classDef devel fill: #bbdefb, color: #333
+    classDef runtime fill: #c8e6c9, color: #333
+    classDef cuda fill: #e1bee7, color: #333
+    class base base
+    class core-dependencies,core-devel,universe-dependencies,universe-devel devel
+    class core,universe-runtime-dependencies,universe runtime
+    class universe-dependencies-cuda,universe-devel-cuda,universe-cuda cuda
+```
+
+## Images
+
+| Image                           | Description                                                                          | Use case                                                   |
+| ------------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
+| `base`                          | ROS base, sudo, pipx, ansible, RMW, user `aw`                                        | Foundation for all other images                            |
+| `core-dependencies`             | Build deps + compiled core packages (except autoware_core and autoware_rviz_plugins) | CI for autoware_core                                       |
+| `core-devel`                    | Adds autoware_core build on top of core-dependencies                                 | Development and CI for packages depending on autoware_core |
+| `core`                          | Runtime-only: rosdep exec deps + compiled core from core-devel                       | Lightweight core runtime                                   |
+| `universe-dependencies`         | Ansible universe roles + rosdep build deps for all of autoware                       | CI for autoware_universe                                   |
+| `universe-dependencies-cuda`    | Adds CUDA, TensorRT, spconv dev libs                                                 | CI for CUDA-dependent packages                             |
+| `universe-devel`                | Builds all universe sources (no CUDA)                                                | Development without GPU                                    |
+| `universe-devel-cuda`           | Builds all universe sources with CUDA                                                | Development with GPU                                       |
+| `universe-runtime-dependencies` | Runtime ansible roles + rosdep exec deps                                             | Foundation for final runtime images                        |
+| `universe`                      | Runtime image with compiled autoware (no CUDA)                                       | Deployment without GPU                                     |
+| `universe-cuda`                 | Runtime image with compiled autoware + CUDA runtime libs                             | Deployment with GPU                                        |
+
+## Build locally
+
+From the repository root. Targets beyond `base` require source repositories under `src/`:
+
+```bash
+# Clone source repositories (needed for core and universe targets)
+vcs import src < repositories/autoware.repos
+
+# Build all default targets (universe + universe-cuda)
+docker buildx bake -f docker-new/docker-bake.hcl
+
+# Build a specific target (dependencies are resolved automatically)
+docker buildx bake -f docker-new/docker-bake.hcl base
+docker buildx bake -f docker-new/docker-bake.hcl core-devel
+docker buildx bake -f docker-new/docker-bake.hcl universe
+docker buildx bake -f docker-new/docker-bake.hcl universe-cuda
+
+# Build for humble
+ROS_DISTRO=humble docker buildx bake -f docker-new/docker-bake.hcl base
+```
+
+## Usage
+
+```bash
+xhost +local:docker
+
+docker run --rm -it \
+  --net host \
+  --privileged \
+  --gpus all \
+  -e DISPLAY=$DISPLAY \
+  -e NVIDIA_DRIVER_CAPABILITIES=all \
+  -e NVIDIA_VISIBLE_DEVICES=all \
+  -e HOST_UID=$(id -u) \
+  -e HOST_GID=$(id -g) \
+  -e QT_X11_NO_MITSHM=1 \
+  -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
+  -v $HOME/autoware_map:/home/aw/autoware_map \
+  -v $HOME/autoware_data:/home/aw/autoware_data \
+  -v $HOME/autoware:/home/aw/autoware \
+  -w /home/aw/autoware \
+  --runtime=nvidia \
+  autoware:universe-cuda-jazzy \
+  bash -c "source /opt/autoware/setup.bash && exec bash"
+```
+
+| Flag                                | Why                                                                                                  |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `--rm`                              | Remove container on exit to avoid accumulating stopped containers                                    |
+| `-it`                               | Interactive terminal (stdin + TTY)                                                                   |
+| `--net host`                        | Share host network stack so ROS 2 nodes can discover each other                                      |
+| `--privileged`                      | Access to host devices (sensors, CAN bus, etc.)                                                      |
+| `--gpus all`                        | Expose all GPUs to the container                                                                     |
+| `-e DISPLAY`                        | Forward X11 display for GUI applications (rviz2, rqt)                                                |
+| `-e NVIDIA_DRIVER_CAPABILITIES=all` | Enable all NVIDIA driver features (compute, graphics, video)                                         |
+| `-e NVIDIA_VISIBLE_DEVICES=all`     | Make all GPUs visible inside the container                                                           |
+| `-e HOST_UID/HOST_GID`              | Entrypoint remaps the `aw` user to match host UID/GID, avoiding permission issues on mounted volumes |
+| `-e QT_X11_NO_MITSHM`               | Disable MIT-SHM for Qt apps (shared memory doesn't work across container boundary)                   |
+| `-v /tmp/.X11-unix`                 | Mount X11 socket for GUI forwarding                                                                  |
+| `-v autoware_map`                   | Mount map data from host                                                                             |
+| `-v autoware_data`                  | Mount perception model data from host                                                                |
+| `-v autoware`                       | Mount source code for development                                                                    |
+| `-w /home/aw/autoware`              | Set working directory to the mounted source                                                          |
+| `--runtime=nvidia`                  | Use NVIDIA container runtime for GPU support                                                         |
+
+Or run without volume mounting:
+
+```bash
+docker run --rm -it \
+  --net host \
+  autoware:core-jazzy
+```
+
+The default CycloneDDS config uses the `lo` interface (localhost only). To override it, mount your own config:
+
+```bash
+docker run --rm -it \
+  --net host \
+  -v /path/to/your/cyclonedds.xml:/home/aw/cyclonedds.xml \
+  autoware:universe-cuda-jazzy
+```

--- a/docker-new/base.Dockerfile
+++ b/docker-new/base.Dockerfile
@@ -1,0 +1,63 @@
+# check=skip=InvalidDefaultArgInFrom
+ARG ROS_DISTRO
+
+FROM ros:${ROS_DISTRO}-ros-base AS base
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG ROS_DISTRO
+ARG USERNAME=aw
+
+RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache && \
+    echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/99-no-recommends && \
+    echo 'APT::Install-Suggests "false";' >> /etc/apt/apt.conf.d/99-no-recommends
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    sudo \
+    pipx \
+    bash-completion \
+    gosu
+
+# Remove default ubuntu user (present since 24.04, occupies UID 1000)
+RUN userdel -r ubuntu 2>/dev/null || true && \
+    useradd -m -s /bin/bash -U ${USERNAME} && \
+    echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/90-user-nopasswd && \
+    chmod 0440 /etc/sudoers.d/90-user-nopasswd && \
+    sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /home/${USERNAME}/.bashrc
+
+USER ${USERNAME}
+WORKDIR /home/${USERNAME}
+
+# Make pipx shims visible during build steps and at runtime
+ENV PATH="/home/${USERNAME}/.local/bin:${PATH}"
+
+ENV ANSIBLE_COLLECTIONS_PATH="/home/${USERNAME}/.ansible/collections"
+
+# hadolint ignore=DL3003
+RUN --mount=type=bind,source=ansible-galaxy-requirements.yaml,target=/tmp/ansible/ansible-galaxy-requirements.yaml \
+    --mount=type=bind,source=ansible,target=/tmp/ansible/ansible \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/home/aw/.cache/pipx,uid=1000,gid=1000 \
+    pipx install --include-deps "ansible==10.*" && \
+    cd /tmp/ansible && \
+    ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml && \
+    ansible-playbook autoware.dev_env.autoware_requirements \
+      --tags rmw \
+      -e rosdistro=${ROS_DISTRO} && \
+    pipx uninstall ansible
+
+COPY docker-new/files/cyclonedds.xml /home/${USERNAME}/cyclonedds.xml
+ENV CYCLONEDDS_URI=file:///home/${USERNAME}/cyclonedds.xml
+
+# Entrypoint runs as root so it can adjust UID/GID, then drops to user
+USER root
+COPY --chmod=755 docker-new/docker-entrypoint.sh /docker-entrypoint.sh
+
+ENV ROS_DISTRO=${ROS_DISTRO}
+ENV USERNAME=${USERNAME}
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/docker-new/core.Dockerfile
+++ b/docker-new/core.Dockerfile
@@ -1,0 +1,102 @@
+# syntax=docker/dockerfile:1
+# check=skip=InvalidDefaultArgInFrom
+ARG BASE_IMAGE
+
+FROM ${BASE_IMAGE} AS core-dependencies
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+USER ${USERNAME}
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/home/aw/.cache/pip,uid=1000,gid=1000 \
+    --mount=type=cache,target=/home/aw/.cache/pipx,uid=1000,gid=1000 \
+    pipx install --include-deps "ansible==10.*" && \
+    ansible-playbook autoware.dev_env.autoware_requirements \
+      --tags core \
+      --skip-tags base \
+      -e "rosdistro=${ROS_DISTRO}" && \
+    pipx uninstall ansible
+USER root
+
+ENV CC="/usr/lib/ccache/gcc"
+ENV CXX="/usr/lib/ccache/g++"
+ENV CCACHE_DIR="/home/aw/.ccache"
+
+COPY --parents --chown=${USERNAME}:${USERNAME} src/core/**/package.xml /tmp/autoware/
+RUN rm -rf /tmp/autoware/src/core/autoware_core /tmp/autoware/src/core/autoware_rviz_plugins
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && \
+    . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
+    rosdep install -y --from-paths /tmp/autoware/src/core \
+      --ignore-src \
+      --rosdistro "${ROS_DISTRO}" \
+      --dependency-types=build \
+      --dependency-types=build_export \
+      --dependency-types=buildtool \
+      --dependency-types=buildtool_export \
+      --dependency-types=test
+
+RUN --mount=type=bind,source=src/core,target=/tmp/autoware/src/core,rw \
+    --mount=type=cache,target=/home/aw/.ccache,uid=1000,gid=1000 \
+    rm -rf /tmp/autoware/src/core/autoware_core \
+           /tmp/autoware/src/core/autoware_rviz_plugins && \
+    . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
+    colcon build \
+      --base-paths /tmp/autoware/src/core \
+      --install-base /opt/autoware \
+      --cmake-args -DCMAKE_BUILD_TYPE=Release && \
+    rm -rf build log
+
+FROM core-dependencies AS core-devel
+
+COPY --parents --chown=${USERNAME}:${USERNAME} \
+    src/core/autoware_core/**/package.xml \
+    src/core/autoware_rviz_plugins/**/package.xml \
+    /tmp/autoware/
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && \
+    . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
+    . /opt/autoware/setup.sh && \
+    rosdep install -y --from-paths /tmp/autoware/src/core \
+      --ignore-src \
+      --rosdistro "${ROS_DISTRO}" \
+      --dependency-types=build \
+      --dependency-types=build_export \
+      --dependency-types=buildtool \
+      --dependency-types=buildtool_export \
+      --dependency-types=test
+
+RUN --mount=type=bind,source=src/core/autoware_core,target=/tmp/autoware/src/core/autoware_core \
+    --mount=type=bind,source=src/core/autoware_rviz_plugins,target=/tmp/autoware/src/core/autoware_rviz_plugins \
+    --mount=type=cache,target=/home/aw/.ccache,uid=1000,gid=1000 \
+    . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
+    . /opt/autoware/setup.sh && \
+    colcon build \
+      --base-paths /tmp/autoware/src/core/autoware_core \
+                   /tmp/autoware/src/core/autoware_rviz_plugins \
+      --install-base /opt/autoware \
+      --cmake-args -DCMAKE_BUILD_TYPE=Release && \
+    rm -rf build log
+
+FROM ${BASE_IMAGE} AS core
+ENV AUTOWARE_RUNTIME=1
+
+COPY --from=core-devel /opt/autoware /opt/autoware
+RUN find /opt/autoware -name '*.so' -exec strip --strip-unneeded {} +
+
+COPY --parents src/core/**/package.xml /tmp/
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && \
+    . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
+    sudo apt-get install -y "ros-${ROS_DISTRO}-topic-tools" && \
+    rosdep install -y --from-paths /tmp/src/core \
+      --dependency-types=exec \
+      --ignore-src \
+      --rosdistro "${ROS_DISTRO}" && \
+    rm -rf /tmp/src

--- a/docker-new/docker-bake.hcl
+++ b/docker-new/docker-bake.hcl
@@ -1,0 +1,132 @@
+variable "ROS_DISTRO" {
+  default = "jazzy"
+}
+
+function "tags" {
+  params = [name]
+  result = ["autoware:${name}-${ROS_DISTRO}"]
+}
+
+group "default" {
+  targets = ["base",
+             "core-dependencies", "core-devel", "core",
+             "universe-dependencies", "universe-devel",
+             "universe-runtime-dependencies", "universe",
+             "universe-dependencies-cuda", "universe-devel-cuda", "universe-cuda"]
+}
+
+group "ci-base" {
+  targets = ["base"]
+}
+
+group "ci-core" {
+  targets = ["core-dependencies", "core-devel", "core"]
+}
+
+group "ci-universe" {
+  targets = ["universe-dependencies", "universe-devel",
+             "universe-runtime-dependencies", "universe"]
+}
+
+group "ci-universe-cuda" {
+  targets = ["universe-dependencies-cuda", "universe-devel-cuda", "universe-cuda"]
+}
+
+target "base" {
+  dockerfile = "docker-new/base.Dockerfile"
+  target     = "base"
+  tags       = tags("base")
+  args = {
+    ROS_DISTRO = ROS_DISTRO
+  }
+}
+
+target "core-dependencies" {
+  dockerfile = "docker-new/core.Dockerfile"
+  target     = "core-dependencies"
+  tags       = tags("core-dependencies")
+  contexts = {
+    autoware-base = "target:base"
+  }
+  args = {
+    BASE_IMAGE = "autoware-base"
+  }
+}
+
+target "core-devel" {
+  dockerfile = "docker-new/core.Dockerfile"
+  target     = "core-devel"
+  tags       = tags("core-devel")
+  contexts = {
+    autoware-base = "target:base"
+  }
+  args = {
+    BASE_IMAGE = "autoware-base"
+  }
+}
+
+target "core" {
+  dockerfile = "docker-new/core.Dockerfile"
+  target     = "core"
+  tags       = tags("core")
+  contexts = {
+    autoware-base = "target:base"
+  }
+  args = {
+    BASE_IMAGE = "autoware-base"
+  }
+}
+
+target "_universe-base" {
+  dockerfile = "docker-new/universe.Dockerfile"
+  contexts = {
+    autoware-core-devel = "target:core-devel"
+    autoware-core       = "target:core"
+  }
+  args = {
+    CORE_DEVEL_IMAGE = "autoware-core-devel"
+    CORE_IMAGE       = "autoware-core"
+  }
+}
+
+target "universe-dependencies" {
+  inherits = ["_universe-base"]
+  target   = "universe-dependencies"
+  tags     = tags("universe-dependencies")
+}
+
+target "universe-dependencies-cuda" {
+  inherits = ["_universe-base"]
+  target   = "universe-dependencies-cuda"
+  tags     = tags("universe-dependencies-cuda")
+}
+
+target "universe-devel-cuda" {
+  inherits = ["_universe-base"]
+  target   = "universe-devel-cuda"
+  tags     = tags("universe-devel-cuda")
+}
+
+target "universe-devel" {
+  inherits = ["_universe-base"]
+  target   = "universe-devel"
+  tags     = tags("universe-devel")
+}
+
+target "universe-runtime-dependencies" {
+  inherits = ["_universe-base"]
+  target   = "universe-runtime-dependencies"
+  tags     = tags("universe-runtime-dependencies")
+}
+
+target "universe" {
+  inherits = ["_universe-base"]
+  target   = "universe"
+  tags     = tags("universe")
+}
+
+target "universe-cuda" {
+  inherits = ["_universe-base"]
+  target   = "universe-cuda"
+  tags     = tags("universe-cuda")
+}

--- a/docker-new/docker-entrypoint.sh
+++ b/docker-new/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# Remap aw user to match host UID/GID (avoids permission issues with mounted volumes)
+if [ -n "${HOST_UID}" ] && [ -n "${HOST_GID}" ]; then
+    usermod -u "${HOST_UID}" "${USERNAME}" >/dev/null 2>&1 || true
+    groupmod -g "${HOST_GID}" "${USERNAME}" >/dev/null 2>&1 || true
+fi
+
+# shellcheck source=/dev/null
+source "/opt/ros/${ROS_DISTRO}/setup.bash"
+
+if [ "${AUTOWARE_RUNTIME}" = "1" ] && [ -f /opt/autoware/setup.bash ]; then
+    # shellcheck source=/dev/null
+    source /opt/autoware/setup.bash
+fi
+
+exec gosu "${USERNAME}" "$@"

--- a/docker-new/files/cyclonedds.xml
+++ b/docker-new/files/cyclonedds.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CycloneDDS xmlns="https://cdds.io/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="https://cdds.io/config https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd">
+  <Domain Id="any">
+    <Discovery>
+      <ParticipantIndex>none</ParticipantIndex>
+    </Discovery>
+    <General>
+      <Interfaces>
+        <NetworkInterface name="lo" priority="default" multicast="default"/>
+      </Interfaces>
+      <AllowMulticast>default</AllowMulticast>
+      <MaxMessageSize>65500B</MaxMessageSize>
+    </General>
+    <Internal>
+      <SocketReceiveBufferSize min="10MB"/>
+      <Watermarks>
+        <WhcHigh>500kB</WhcHigh>
+      </Watermarks>
+    </Internal>
+  </Domain>
+</CycloneDDS>

--- a/docker-new/universe.Dockerfile
+++ b/docker-new/universe.Dockerfile
@@ -1,0 +1,146 @@
+# syntax=docker/dockerfile:1
+# check=skip=InvalidDefaultArgInFrom,UndefinedVar
+ARG CORE_DEVEL_IMAGE
+ARG CORE_IMAGE
+
+FROM ${CORE_DEVEL_IMAGE} AS universe-dependencies
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install universe ansible roles (repeated in universe-runtime-dependencies below
+# because that stage starts from a different base image and cannot share layers)
+USER ${USERNAME}
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/home/aw/.cache/pip,uid=1000,gid=1000 \
+    --mount=type=cache,target=/home/aw/.cache/pipx,uid=1000,gid=1000 \
+    pipx install --include-deps "ansible==10.*" && \
+    ansible-playbook autoware.dev_env.autoware_requirements \
+      --tags universe \
+      --skip-tags core,nvidia,artifacts \
+      -e "rosdistro=${ROS_DISTRO}" && \
+    sudo rm -rf /opt/acados/.git /opt/acados/examples /opt/acados/docs /opt/acados/test && \
+    pipx uninstall ansible
+USER root
+
+ENV CMAKE_PREFIX_PATH="/opt/acados${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
+ENV ACADOS_SOURCE_DIR="/opt/acados"
+ENV LD_LIBRARY_PATH="/opt/acados/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+COPY --parents --chown=${USERNAME}:${USERNAME} src/**/package.xml /tmp/autoware/
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && \
+    . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
+    . /opt/autoware/setup.sh && \
+    rosdep install -y --from-paths /tmp/autoware/src \
+      --ignore-src \
+      --rosdistro "${ROS_DISTRO}" \
+      --dependency-types=build \
+      --dependency-types=build_export \
+      --dependency-types=buildtool \
+      --dependency-types=buildtool_export \
+      --dependency-types=test
+
+FROM universe-dependencies AS universe-dependencies-cuda
+
+USER ${USERNAME}
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/home/aw/.cache/pipx,uid=1000,gid=1000 \
+    pipx install --include-deps "ansible==10.*" && \
+    ansible-playbook autoware.dev_env.autoware_requirements \
+      --tags nvidia \
+      -e "rosdistro=${ROS_DISTRO}" \
+      -e install_devel=y \
+      -e cuda_install_drivers=false && \
+    pipx uninstall ansible
+USER root
+
+ENV PATH="/usr/local/cuda/bin${PATH:+:$PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+FROM universe-dependencies-cuda AS universe-devel-cuda
+
+RUN --mount=type=bind,source=src,target=/tmp/autoware/src \
+    --mount=type=cache,target=/home/aw/.ccache,uid=1000,gid=1000,sharing=shared \
+    . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
+    . /opt/autoware/setup.sh && \
+    colcon build \
+      --base-paths /tmp/autoware/src \
+      --install-base /opt/autoware \
+      --cmake-args -DCMAKE_BUILD_TYPE=Release && \
+    rm -rf build log
+
+FROM universe-dependencies AS universe-devel
+
+RUN --mount=type=bind,source=src,target=/tmp/autoware/src \
+    --mount=type=cache,target=/home/aw/.ccache,uid=1000,gid=1000,sharing=shared \
+    CCACHE_READONLY=1 \
+    . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
+    . /opt/autoware/setup.sh && \
+    colcon build \
+      --base-paths /tmp/autoware/src \
+      --install-base /opt/autoware \
+      --cmake-args -DCMAKE_BUILD_TYPE=Release && \
+    rm -rf build log
+
+FROM ${CORE_IMAGE} AS universe-runtime-dependencies
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+USER ${USERNAME}
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/home/aw/.cache/pip,uid=1000,gid=1000 \
+    --mount=type=cache,target=/home/aw/.cache/pipx,uid=1000,gid=1000 \
+    pipx install --include-deps "ansible==10.*" && \
+    ansible-playbook autoware.dev_env.autoware_requirements \
+      --tags universe \
+      --skip-tags core,nvidia,artifacts \
+      -e "rosdistro=${ROS_DISTRO}" && \
+    sudo rm -rf /opt/acados/.git /opt/acados/examples /opt/acados/docs /opt/acados/test && \
+    pipx uninstall ansible
+USER root
+
+ENV CMAKE_PREFIX_PATH="/opt/acados${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
+ENV ACADOS_SOURCE_DIR="/opt/acados"
+ENV LD_LIBRARY_PATH="/opt/acados/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+COPY --parents --chown=${USERNAME}:${USERNAME} src/**/package.xml /tmp/
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && \
+    . "/opt/ros/${ROS_DISTRO}/setup.sh" && \
+    . /opt/autoware/setup.sh && \
+    rosdep install -y --from-paths /tmp/src \
+      --dependency-types=exec \
+      --ignore-src \
+      --rosdistro "${ROS_DISTRO}" && \
+    rm -rf /tmp/src
+
+FROM universe-runtime-dependencies AS universe
+
+COPY --from=universe-devel /opt/autoware /opt/autoware
+RUN find /opt/autoware -name '*.so' -exec strip --strip-unneeded {} +
+
+FROM universe-runtime-dependencies AS universe-cuda
+
+USER ${USERNAME}
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/home/aw/.cache/pipx,uid=1000,gid=1000 \
+    pipx install --include-deps "ansible==10.*" && \
+    ansible-playbook autoware.dev_env.autoware_requirements \
+      --tags nvidia \
+      -e "rosdistro=${ROS_DISTRO}" \
+      -e install_devel=N \
+      -e cuda_install_drivers=false && \
+    pipx uninstall ansible
+USER root
+
+ENV PATH="/usr/local/cuda/bin${PATH:+:$PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+COPY --from=universe-devel-cuda /opt/autoware /opt/autoware
+RUN find /opt/autoware -name '*.so' -exec strip --strip-unneeded {} +


### PR DESCRIPTION
- **Parent issue:** #7003
- Add 3 Dockerfiles (`base`, `core`, `universe`) defining 11 multi-stage image targets
- Add `docker-bake.hcl` for local builds via `docker buildx bake`
- Add [`autoware_requirements.yaml`](https://github.com/autowarefoundation/autoware/blob/1e0efff409d882c0012a666f48f59b91443c5d19/ansible/playbooks) ansible playbook with tag-based role selection replacing `setup-dev-env.sh` conditionals

## Why

The current Docker pipeline uses a single 555-line monolith Dockerfile with 18 component-split stages and `.env`-driven configuration. This PR lays the foundation for a simpler replacement: ansible tags select roles per image tier (base/core/universe/nvidia), buildx bake resolves the dependency graph, and the image count drops from 18 to 11 unified images. This is purely additive -- nothing in the existing pipeline is touched.

## Image size comparison

| Old pipeline | Size | New pipeline | Size | Delta |
|---|---|---|---|---|
| `core-common-devel` | 7.21 GB | `core-dependencies-jazzy` | 5.44 GB | **-25%** |
| `core-devel-jazzy` | 8.53 GB | `core-devel-jazzy` | 6.23 GB | **-27%** |
| `universe-common-devel-jazzy` | 9.17 GB | `universe-dependencies-jazzy` | 9.23 GB | +1% |
| `universe-devel-jazzy` | 11.7 GB | `universe-devel-jazzy` | 10.6 GB | **-9%** |
| `universe-devel-jazzy-cuda` | 37.1 GB | `universe-devel-cuda-jazzy` | 36.2 GB | **-2%** |

<details>
<summary>Why is universe-dependencies +1% larger?</summary>

The actual filesystem content is **108 MB smaller** in the new image (`du -sx /`: 6.54 GB vs 6.65 GB). The +1% Docker image size difference is layer overhead from the multi-stage build approach (COPY layers, whiteout entries from bind mount cleanup, etc.). The layer sums are nearly identical (5.91 GB vs 5.87 GB).

</details>

---

- Image design details: #6852
- Migration roadmap: #7003
- Existing Total PR (will be closed): #6851

## Test plan

- [x] Validate bake config parses correctly:
  ```
  docker buildx bake -f docker-new/docker-bake.hcl --print
  ```
- [x] Build base image (no source repos needed):
  ```
  docker buildx bake -f docker-new/docker-bake.hcl base
  ```
- [x] Build all default targets:
  ```
  vcs import src < repositories/autoware.repos
  docker buildx bake -f docker-new/docker-bake.hcl
  ```
- [x] [AWSIM tutorial](https://autowarefoundation.github.io/autoware-documentation/main/demos/digital-twin-demos/awsim-tutorial/) passes with locally built images
- [X] [Autoware Core AWSIM demo](https://autowarefoundation.github.io/autoware-documentation/main/demos/digital-twin-demos/autoware-core-awsim/) launches.
   - It can't pass because the latest autoware_core release doesn't pass either. See the demo notes below.

### Full AWSIM Demo

▶️ **VIDEO:** https://youtu.be/c8TwD6pM0DU

Make sure you have [the Shinjuku-Map](https://github.com/tier4/AWSIM/releases/download/v2.0.0/Shinjuku-Map.zip) in the correct place on host.

Also on the host `~/autoware_data` should be present and [populated](https://github.com/autowarefoundation/autoware/blob/main/ansible/roles/artifacts/README.md).

```console
# Host
mfc@whale:~/autoware_map$ tree Shinjuku-Map
Shinjuku-Map
├── CMakeLists.txt
├── LICENSE
├── map
│   ├── lanelet2_map.osm
│   └── pointcloud_map.pcd
└── package.xml
```

Then run the container.

```
docker run --rm -it \
  --net host \
  --privileged \
  --gpus all \
  -e DISPLAY=$DISPLAY \
  -e NVIDIA_DRIVER_CAPABILITIES=all \
  -e NVIDIA_VISIBLE_DEVICES=all \
  -e HOST_UID=$(id -u) \
  -e HOST_GID=$(id -g) \
  -e QT_X11_NO_MITSHM=1 \
  -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
  -v $HOME/autoware_map:/home/aw/autoware_map \
  -v $HOME/autoware_data:/home/aw/autoware_data \
  -v $HOME/projects/autoware:/home/aw/autoware \ #🚨Adjust your autoware path, not needed in demo
  -w /home/aw/autoware \
  --runtime=nvidia \
  autoware:universe-cuda-jazzy \
  bash -c "source /opt/autoware/setup.bash && exec bash"
```

The default CycloneDDS config uses the `lo` interface (localhost only). To override it, you can mount your own config:
```
  -v /path/to/your/cyclonedds.xml:/home/aw/cyclonedds.xml \
```
But if you followed https://autowarefoundation.github.io/autoware-documentation/main/installation/additional-settings-for-developers/network-configuration/dds-settings/ you don't have to worry about this, everything else will work.

Download, extract, `chmod +x` and run https://github.com/tier4/AWSIM/releases/download/v2.0.1/AWSIM-Demo-Lightweight.zip on another terminal.

Then it should automatically localize.
You can ignore the initial "Failed to parse type hash" warnings.

### Core only AWSIM Demo

Unfortunately the fix for this demo is not patched to the `1.7.2` so the launch file fails.

<img width="1489" height="291" alt="image" src="https://github.com/user-attachments/assets/bf513ffc-5536-4168-ba09-24fe16c64d0e" />

But you can launch it like so:

```
docker run --rm -it \
  --net host \
  --privileged \
  --gpus all \
  -e DISPLAY=$DISPLAY \
  -e NVIDIA_DRIVER_CAPABILITIES=all \
  -e NVIDIA_VISIBLE_DEVICES=all \
  -e HOST_UID=$(id -u) \
  -e HOST_GID=$(id -g) \
  -e QT_X11_NO_MITSHM=1 \
  -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
  -v $HOME/autoware_map:/home/aw/autoware_map \
  -v $HOME/autoware_data:/home/aw/autoware_data \
  -w /home/aw/autoware \
  --runtime=nvidia \
  autoware:core-jazzy \
  bash -c "source /opt/autoware/setup.bash && exec bash"
```

```
ros2 launch autoware_core autoware_core.launch.xml \
  use_sim_time:=true \
  map_path:=/home/aw/autoware_map/Shinjuku-Map/map \
  vehicle_model:=autoware_sample_vehicle \
  sensor_model:=autoware_awsim_sensor_kit
```

- Though it will fail unless you patch the https://github.com/autowarefoundation/autoware_core/pull/975

I didn't bother for now. [The instructions](https://autowarefoundation.github.io/autoware-documentation/main/demos/digital-twin-demos/autoware-core-awsim/) are not well polished anyways.

I also added `ros-jazzy-topic-tools` to the runtime image so no need to reinstall.

