### PR TITLE
ci(docker): replace health-check workflow with docker-new pipeline

### DIFF
--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -143,8 +143,8 @@ jobs:
           load: true
           provenance: false
           set: |
-            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ matrix.platform }}-main
-            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ matrix.build-type }}-${{ matrix.platform }}-main
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:humble-${{ matrix.platform }}-main
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ matrix.build-type }}-humble-${{ matrix.platform }}-main
 
       - name: 💾 Save Docker image
         if: ${{ matrix.build-type == 'main' &&

--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -33,7 +33,7 @@ jobs:
         include:
           - build-type: main
             platform: amd64
-            runner: "['self-hosted','Linux','X64']"
+            runner: "['ubuntu-24.04']"
           - build-type: nightly
             platform: amd64
             runner: "['ubuntu-24.04']"

--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -34,79 +34,53 @@ jobs:
           - build-type: main
             platform: amd64
             runner: "['self-hosted','Linux','X64']"
-            lib-dir: x86_64
-            container: ubuntu:22.04
           - build-type: nightly
             platform: amd64
             runner: "['ubuntu-24.04']"
-            lib-dir: x86_64
           - build-type: main-arm64
             platform: arm64
             runner: "['ubuntu-24.04-arm']"
-            lib-dir: aarch64
     runs-on: ${{ fromJson(matrix.runner) }}
     steps:
-      - name: Clean up previous run artifacts
-        run: sudo rm -rf ${{ github.workspace }}/scenario_out
-      # https://github.com/actions/checkout/issues/211
-      - name: Change permission of workspace
+      - name: 🔧 Change permission of workspace
         run: |
+          sudo rm -rf ${{ github.workspace }}/scenario_out
           sudo chown -R $USER:$USER ${{ github.workspace }}
 
-      - name: Check out repository
-        uses: actions/checkout@v4
+      - name: 📥 Check out repository
+        uses: actions/checkout@v6
 
-      - name: Derive image names
-        id: derive
-        uses: ./.github/actions/derive-image-names
-        with:
-          rosdistro: humble
-
-      - name: Set git config
-        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get changed files
+      - name: 📂 Get changed files
         id: changed-files
-        uses: step-security/changed-files@v46
+        uses: step-security/changed-files@v47
         with:
           files: |
             repositories/*.repos
-            .github/actions/docker-build/action.yaml
             .github/workflows/health-check.yaml
             ansible-galaxy-requirements.yaml
             ansible/**
-            docker/**
-            setup-dev-env.sh
+            docker-new/**
 
-      - name: Show disk space
-        if: always()
-        run: |
-          df -h
-
-      - name: Free disk space
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' &&
-          matrix.build-type != 'main' }}
-        uses: ./.github/actions/free-disk-space
-
-      - name: Show runner info
+      - name: 💻 Runner specs
         run: |
           echo "::group::CPU"
-          nproc
-          lscpu
+          lscpu | grep -E "^(Architecture|CPU\(s\)|Model name|Thread|Core|Socket)"
           echo "::endgroup::"
           echo "::group::Memory"
           free -h
           echo "::endgroup::"
-          echo "::group::Swap"
-          swapon --show
-          echo "::endgroup::"
           echo "::group::Disk"
-          df -h
+          df -h /
           echo "::endgroup::"
 
-      - name: Create additional swap
+      - name: 🧹 Free disk space
+        if: ${{ matrix.build-type != 'main' &&
+          (steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch') }}
+        uses: ./.github/actions/free-disk-space
+
+      - name: 💾 Create additional swap
         if: ${{ matrix.platform == 'arm64' &&
           (steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'schedule' ||
@@ -117,30 +91,84 @@ jobs:
           sudo mkswap /mnt/swapfile
           sudo swapon /mnt/swapfile
           free -h
-          swapon --show
 
-      - name: Build 'Autoware'
+      - name: 📦 Import source repos
         if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch' }}
-        uses: ./.github/actions/docker-build
-        with:
-          platform: ${{ matrix.platform }}
-          cache-tag-suffix: ${{ matrix.build-type }}
-          image-artifact-name: ${{ matrix.build-type == 'main' && 'autoware-image' || '' }}
-          additional-repos: ${{ matrix.build-type == 'nightly' && 'repositories/autoware-nightly.repos' || '' }}
-          build-args: |
-            ROS_DISTRO=${{ steps.derive.outputs.rosdistro }}
-            AUTOWARE_BASE_IMAGE=${{ steps.derive.outputs.autoware_base_image }}
-            AUTOWARE_BASE_CUDA_IMAGE=${{ steps.derive.outputs.autoware_base_cuda_image }}
-            LIB_DIR=${{ matrix.lib-dir }}
-
-      - name: Show disk space
-        if: always()
         run: |
-          df -h
+          pipx install vcs2l
+          mkdir -p src
+          vcs import --shallow src < repositories/autoware.repos
+
+      - name: 📦 Overlay nightly repos
+        if: ${{ matrix.build-type == 'nightly' &&
+          (steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch') }}
+        run: |
+          vcs import --shallow --force src < repositories/autoware-nightly.repos
+
+      - name: 🐳 Setup Docker Buildx
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch' }}
+        uses: docker/setup-buildx-action@v4
+        with:
+          buildkitd-config-inline: |
+            [worker.oci]
+              max-parallelism = 2
+
+      - name: 🔑 Login to GitHub Container Registry
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch' }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: 🔨 Build Autoware (docker-new)
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch' }}
+        uses: docker/bake-action@v7
+        env:
+          ROS_DISTRO: humble
+        with:
+          source: .
+          targets: universe-devel
+          files: docker-new/docker-bake.hcl
+          load: true
+          provenance: false
+          set: |
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ matrix.platform }}-main
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ matrix.build-type }}-${{ matrix.platform }}-main
+
+      - name: 💾 Save Docker image
+        if: ${{ matrix.build-type == 'main' &&
+          (steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch') }}
+        run: docker save autoware:universe-devel-humble | gzip > /tmp/autoware-image.tar.gz
+
+      - name: 📤 Upload Docker image artifact
+        if: ${{ matrix.build-type == 'main' &&
+          (steps.changed-files.outputs.any_changed == 'true' ||
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch') }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: autoware-image
+          path: /tmp/autoware-image.tar.gz
+
+      - name: 📊 Disk space
+        if: always()
+        run: df -h
+
   scenario-test:
     needs: docker-build
     uses: ./.github/workflows/scenario-test-reusable.yaml
     with:
-      autoware_container_image: autoware:health-check-${{ github.sha }}
+      autoware_container_image: autoware:universe-devel-humble


### PR DESCRIPTION
- **Parent Issue:** #7003
- Replace the old `health-check.yaml` workflow (which used `.github/actions/docker-build`) with the new `docker-new/` HCL bake pipeline
- Drop unused matrix fields (`lib-dir`, `container`), removed `derive-image-names` and `set-git-config` steps
- Update action versions (`checkout@v6`, `changed-files@v47`, `upload-artifact@v7`) and changed-files filter to watch `docker-new/**` instead of `docker/**`

## Why

- The new docker pipeline landed in #7004 and #7012.

The health-check workflow still used the old `docker-build` action and old Dockerfiles. This replaces it so health checks validate the new pipeline directly, removing a dependency on the old `docker/` tree ahead of its deletion.

---

- Depends on #7012

## Test plan

- [x] Add `run:health-check` label to this PR and verify the `health-check` workflow triggers
- [ ] Confirm all three matrix jobs (main, nightly, main-arm64) start and the bake build pulls cache from `ghcr.io/autowarefoundation/autoware-buildcache-new`
- [ ] Verify the `main` amd64 job uploads the `autoware-image` artifact and the `scenario-test` job loads `autoware:universe-devel-humble` successfully