### PR TITLE
fix(docker): include ROS distro in buildcache-new cache keys

### DIFF
--- a/.github/workflows/docker-build-new.yaml
+++ b/.github/workflows/docker-build-new.yaml
@@ -147,11 +147,11 @@ jobs:
           set: |
             *.platform=${{ matrix.arch-platform }}
             *.args.ROS_DISTRO=${{ inputs.ros-distro }}
-            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ inputs.cache-key-prefix }}${{ matrix.platform }}-${{ steps.meta.outputs.ref_name }}
-            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ matrix.platform }}-${{ steps.meta.outputs.ref_name }}
-            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ inputs.cache-key-prefix }}${{ matrix.platform }}-main
-            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ matrix.platform }}-main
-            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ inputs.cache-key-prefix }}${{ matrix.platform }}-${{ steps.meta.outputs.ref_name }},mode=max,ignore-error=true
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ inputs.cache-key-prefix }}${{ inputs.ros-distro }}-${{ matrix.platform }}-${{ steps.meta.outputs.ref_name }}
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ inputs.ros-distro }}-${{ matrix.platform }}-${{ steps.meta.outputs.ref_name }}
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ inputs.cache-key-prefix }}${{ inputs.ros-distro }}-${{ matrix.platform }}-main
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ inputs.ros-distro }}-${{ matrix.platform }}-main
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ inputs.cache-key-prefix }}${{ inputs.ros-distro }}-${{ matrix.platform }}-${{ steps.meta.outputs.ref_name }},mode=max,ignore-error=true
 
       - name: 📊 Build summary
         if: always()


### PR DESCRIPTION
- **Parent Issue:** #7003
- Add `ros-distro` to the build cache key in [`docker-build-new.yaml`](https://github.com/autowarefoundation/autoware/blob/e050a29cfbda9ab2d863d6ad868c858b4cdc4a75/.github/workflows/docker-build-new.yaml) so that humble and jazzy builds use separate cache entries
- Cache key changes from `{prefix}{platform}-{ref}` to `{prefix}{distro}-{platform}-{ref}` (e.g. `humble-amd64-main`, `jazzy-arm64-main`)

## Why

The orchestrator (`docker-build-and-push-new.yaml`) builds both humble and jazzy in parallel, but the cache key had no distro component. Whichever distro finished last would overwrite the other's cache, causing cache misses or incorrect layer reuse on the next run.

---

- Depends on #7012

## Test plan

- [ ] Trigger `docker-build-and-push-new` workflow manually and verify that humble and jazzy jobs write to distinct cache tags (e.g. `humble-amd64-main` vs `jazzy-amd64-main`) in [`autoware-buildcache-new`](https://github.com/autowarefoundation/autoware/pkgs/container/autoware-buildcache-new)
- [ ] Confirm both distros get cache hits on the subsequent run