### PR TITLE
fix(docker): prevent skipped builds when queued runs are dropped

### DIFF
--- a/.github/workflows/docker-build-and-push-new.yaml
+++ b/.github/workflows/docker-build-and-push-new.yaml
@@ -10,18 +10,39 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   changed-files:
     runs-on: ubuntu-24.04
     outputs:
-      should-build: ${{ steps.check.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_type == 'tag') }}
+      should-build: ${{ steps.check.outputs.any_changed == 'true' || steps.last-success.outputs.sha == '' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_type == 'tag') }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Find last successful build commit
+        id: last-success
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sha=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/docker-build-and-push-new.yaml/runs?branch=main&status=success&event=push&per_page=1" \
+            --jq '.workflow_runs[0].head_sha // empty')
+
+          if [ -n "$sha" ] && git cat-file -e "$sha" 2>/dev/null; then
+            echo "sha=$sha" >> "$GITHUB_OUTPUT"
+            echo "Found last successful build at $sha"
+          else
+            echo "sha=" >> "$GITHUB_OUTPUT"
+            echo "No previous successful build found, will force build"
+          fi
+
       - id: check
         uses: step-security/changed-files@v47
         with:
+          base_sha: ${{ steps.last-success.outputs.sha }}
           files: |
             docker-new/**
             ansible/**


### PR DESCRIPTION
- **Parent Issue:** #7003
- Set `cancel-in-progress: false` so queued builds wait for the active run instead of cancelling it
- Compare changed files against the last successful push-triggered build commit (via GitHub API), not just the parent commit
- If no previous successful build exists, always build

## Why

The docker build workflow uses a concurrency group so only one build runs at a time. With `cancel-in-progress: true`, when a new push arrives, it cancels the active build and drops all queued runs except the latest.

This creates a problem: suppose commit A changes `docker-new/Dockerfile` and starts a build. While that build runs, commits B and C are pushed (neither touches Docker files). GitHub cancels A's build, drops B's queued run, and only runs C. Since C's default behavior is to compare against its parent commit (B), it sees no Docker changes and skips the build. The Dockerfile change from commit A is silently lost.

This PR fixes the issue in two ways:

1. **`cancel-in-progress: false`** -- the active build is never interrupted. Queued runs still get deduplicated by GitHub (only the latest survives), but the running build always completes.

2. **Compare against the last successful build, not the parent commit** -- instead of diffing HEAD against HEAD~1, we query the GitHub API for the SHA of the last successful push-triggered run of this workflow. The `changed-files` action then diffs against that SHA, catching all accumulated changes since the last time Docker images were actually built. If no previous successful run exists (first-ever build), we force a build unconditionally.

---

- Depends on #7012

## Test plan

- [ ] Trigger `docker-build-and-push-new` manually and confirm it runs (no previous success = always build)
- [ ] After a successful run, push a commit that does **not** change tracked files -- verify the workflow skips the build
- [ ] Push two commits in quick succession (first changes `docker-new/`, second changes only a README) -- verify the second run still detects the Docker changes from the first commit