### PR TITLE
fix(ansible): update cumm/spconv binary version for DRIVE Thor comparibility

### DIFF
--- a/ansible/roles/spconv/tasks/main.yaml
+++ b/ansible/roles/spconv/tasks/main.yaml
@@ -10,7 +10,7 @@
 - name: Download the cumm package
   ansible.builtin.get_url:
     mode: "0644"
-    url: https://github.com/autowarefoundation/spconv_cpp/releases/download/spconv_v{{ spconv_version }}%2Bcumm_v{{ spconv_cumm_version }}%2Bcu128/cumm_{{ spconv_cumm_version }}_{{ spconv_normalized_arch }}{{ spconv_arch_suffix }}.deb
+    url: https://github.com/autowarefoundation/spconv_cpp/releases/download/spconv_v{{ spconv_version }}%2Bcumm_v{{ spconv_cumm_version }}%2Bcu128-rev1/cumm_{{ spconv_cumm_version }}_{{ spconv_normalized_arch }}{{ spconv_arch_suffix }}.deb
     dest: /tmp/cumm.deb
 
 - name: Install the cumm package
@@ -22,7 +22,7 @@
 - name: Download the spconv package
   ansible.builtin.get_url:
     mode: "0644"
-    url: https://github.com/autowarefoundation/spconv_cpp/releases/download/spconv_v{{ spconv_version }}%2Bcumm_v{{ spconv_cumm_version }}%2Bcu128/spconv_{{ spconv_version }}_{{ spconv_normalized_arch }}{{ spconv_arch_suffix }}.deb
+    url: https://github.com/autowarefoundation/spconv_cpp/releases/download/spconv_v{{ spconv_version }}%2Bcumm_v{{ spconv_cumm_version }}%2Bcu128-rev1/spconv_{{ spconv_version }}_{{ spconv_normalized_arch }}{{ spconv_arch_suffix }}.deb
     dest: /tmp/spconv.deb
 
 - name: Install the spconv package


### PR DESCRIPTION
This is a joint work with @amadeuszsz and @KSeangTan 

## Description

Updated `cumm` and `spconv` binary versions.
This is because the original ones were not compatible for DRIVE Thor platform.
The new release is named with `-rev1` suffix.
https://github.com/autowarefoundation/spconv_cpp/releases

## How was this PR tested?

 - Checked that the ansible works well.
 - Confirmed that the binary works on NVIDIA DRIVE AGX Thor devkit.
 - Also confirmed [TIER IV INTERNAL](https://star4.slack.com/archives/C09J608H59A/p1775620870785979?thread_ts=1774345163.619479&cid=C09J608H59A)