### PR TITLE
fix(repositories): pin rviz_2d_overlay_plugins to 1.4.0

### DIFF
--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -36,6 +36,11 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_system_designer.git
     version: v0.3.2
+  # Temporary pin, see https://github.com/autowarefoundation/autoware_core/issues/1031
+  core/external/rviz_2d_overlay_plugins:
+    type: git
+    url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
+    version: 1.4.0
   # universe
   universe/autoware_universe:
     type: git


### PR DESCRIPTION
- **Parent Issue:** autowarefoundation/autoware_core#1031
- Pin `rviz_2d_overlay_plugins` to `1.4.0` under `core/external/` in [repositories/autoware.repos](https://github.com/autowarefoundation/autoware/blob/f6bf0821a5c3fa7fdca7033d151f056682d8cdac/repositories/autoware.repos).
- Temporary workaround until upstream cuts a fixed release and the ROS buildfarm rebuilds the Debian package.

## Why

Upstream `rviz_2d_overlay_plugins 1.4.1` (shipped as `ros-jazzy-rviz-2d-overlay-plugins 1.4.1-1noble.20260412.050605` on `packages.ros.org`) has a broken AUTOMOC setup: `librviz_2d_overlay_plugins.so` ends up with undefined vtables for `OverlayTextDisplay` and `PieChartDisplay`, which breaks every downstream RViz plugin that links it — including `rviz_plugins/Path`, `rviz_plugins/Trajectory`, `autoware_overlay_rviz_plugin/SignalDisplay`, and several others across `autoware_rviz_plugins`. Upstream has merged the fix (teamspatzenhirn/rviz_2d_overlay_plugins#26) but not yet tagged a release (tracked at teamspatzenhirn/rviz_2d_overlay_plugins#27); pinning to the last known-good `1.4.0` unblocks everyone in the meantime.

---

## Test plan

- [ ] Import the pinned repo and build it:
  ```
  vcs import src < repositories/autoware.repos && source /opt/ros/jazzy/setup.bash && colcon build --symlink-install --packages-select rviz_2d_overlay_msgs rviz_2d_overlay_plugins --cmake-args -DCMAKE_BUILD_TYPE=Release
  ```
- [ ] Confirm all four vtables are defined (`V`, not `U`):
  ```
  nm -D install/rviz_2d_overlay_plugins/lib/librviz_2d_overlay_plugins.so | grep _ZTVN23rviz_2d_overlay_plugins
  ```
  Expected: `OverlayObject`, `OverlayTextDisplay`, `PieChartDisplay`, `ScopedPixelBuffer` all marked `V`.
- [ ] Launch the planning simulator and confirm no plugin-load errors:
  ```
  source /opt/ros/jazzy/setup.bash && source install/setup.bash && timeout 60 ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit 2>&1 | grep -c "PluginlibFactory.*failed to load"
  ```
  Expected: `0`.
- [ ] Revert this pin once upstream releases `>=1.4.2` and apt serves the fixed package.