### PR TITLE
feat(docker-new): enable lo multicast and DDS sysctl tuning at startup

### DIFF
--- a/docker-new/docker-entrypoint.sh
+++ b/docker-new/docker-entrypoint.sh
@@ -7,6 +7,15 @@ if [ -n "${HOST_UID}" ] && [ -n "${HOST_GID}" ]; then
     groupmod -g "${HOST_GID}" "${USERNAME}" >/dev/null 2>&1 || true
 fi
 
+# Enable multicast on loopback so DDS discovery works when pinned to lo
+ip link set lo multicast on >/dev/null 2>&1 || true
+
+# Apply system-wide network tuning for DDS (needs --privileged or --cap-add=NET_ADMIN)
+# https://autowarefoundation.github.io/autoware-documentation/main/installation/additional-settings-for-developers/network-configuration/dds-settings/#tune-system-wide-network-settings
+sysctl -w net.core.rmem_max=2147483647 >/dev/null 2>&1 || true
+sysctl -w net.ipv4.ipfrag_time=3 >/dev/null 2>&1 || true
+sysctl -w net.ipv4.ipfrag_high_thresh=134217728 >/dev/null 2>&1 || true
+
 # shellcheck source=/dev/null
 source "/opt/ros/${ROS_DISTRO}/setup.bash"
 


### PR DESCRIPTION
- Enable multicast on the loopback interface so Cyclone/FastDDS discovery works when traffic is pinned to `lo`.
- Apply the DDS system-wide network tuning (`net.core.rmem_max`, `net.ipv4.ipfrag_time`, `net.ipv4.ipfrag_high_thresh`) at container startup.
- All calls are guarded with `|| true` so containers without `NET_ADMIN` / `--privileged` still start cleanly.

## Why

The [DDS tuning docs](https://autowarefoundation.github.io/autoware-documentation/main/installation/additional-settings-for-developers/network-configuration/dds-settings/#tune-system-wide-network-settings) ask every user to apply these sysctls manually on the host, and loopback multicast is off by default on most distros. Doing it inside the entrypoint means the `docker-new` image works out of the box for single-host DDS without extra setup steps, while gracefully degrading when capabilities are missing.

---

## Test plan

- [ ] Pull a prebuilt image (or build locally via `docker buildx bake -f docker-new/docker-bake.hcl base`):
  ```
  docker pull ghcr.io/autowarefoundation/autoware-new:base-jazzy
  ```
- [ ] Run privileged and confirm settings were applied:
  ```
  docker run --rm --privileged ghcr.io/autowarefoundation/autoware-new:base-jazzy bash -c "ip -d link show lo | grep -i multicast && sysctl net.core.rmem_max net.ipv4.ipfrag_time net.ipv4.ipfrag_high_thresh"
  ```
  Expect `MULTICAST` flag on `lo` and values `2147483647`, `3`, `134217728`.
- [ ] Run unprivileged and confirm container still starts (sysctls silently skipped):
  ```
  docker run --rm ghcr.io/autowarefoundation/autoware-new:base-jazzy bash -c "echo entrypoint ok"
  ```
  Expect `entrypoint ok` with no fatal errors from the sysctl / `ip link` calls.
- [ ] Smoke test ROS 2 multicast discovery on loopback inside the container (two terms, `ros2 topic pub` / `ros2 topic echo` with `ROS_LOCALHOST_ONLY=1`).