### PR TITLE
ci(apt): harden apt with retries + Azure mirror + archive fallback

### DIFF
--- a/.github/workflows/setup-universe.yaml
+++ b/.github/workflows/setup-universe.yaml
@@ -29,6 +29,18 @@ jobs:
         run: |
           df -h
 
+      - name: Configure apt retries and mirror fallback
+        run: |
+          echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/99-retries
+          echo 'Acquire::http::Timeout "30";' >> /etc/apt/apt.conf.d/99-retries
+          echo 'Acquire::https::Timeout "30";' >> /etc/apt/apt.conf.d/99-retries
+          printf 'http://azure.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu\tpriority:2\n' > /etc/apt/ubuntu-mirrors.list
+          for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+            if [ -f "$f" ]; then
+              sed -E -i 's|http://archive\.ubuntu\.com/ubuntu/?|mirror+file:///etc/apt/ubuntu-mirrors.list|g' "$f"
+            fi
+          done
+
       - name: Install dependencies
         run: |
           apt-get update

--- a/docker-new/base.Dockerfile
+++ b/docker-new/base.Dockerfile
@@ -10,7 +10,16 @@ ARG USERNAME=aw
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache && \
     echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/99-no-recommends && \
-    echo 'APT::Install-Suggests "false";' >> /etc/apt/apt.conf.d/99-no-recommends
+    echo 'APT::Install-Suggests "false";' >> /etc/apt/apt.conf.d/99-no-recommends && \
+    echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/99-retries && \
+    echo 'Acquire::http::Timeout "30";' >> /etc/apt/apt.conf.d/99-retries && \
+    echo 'Acquire::https::Timeout "30";' >> /etc/apt/apt.conf.d/99-retries && \
+    printf 'http://azure.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu\tpriority:2\n' > /etc/apt/ubuntu-mirrors.list && \
+    for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do \
+      if [ -f "$f" ]; then \
+        sed -E -i 's|http://archive\.ubuntu\.com/ubuntu/?|mirror+file:///etc/apt/ubuntu-mirrors.list|g' "$f"; \
+      fi; \
+    done
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update && \


### PR DESCRIPTION
- **Parent Issue:** #6852
- Add `Acquire::Retries "5"` with 30s HTTP(S) timeouts via `/etc/apt/apt.conf.d/99-retries` to survive transient TCP flakes against `archive.ubuntu.com`.
- Introduce `/etc/apt/ubuntu-mirrors.list` pinning `azure.archive.ubuntu.com` (`priority:1`) as primary and `archive.ubuntu.com` (`priority:2`) as failsafe, then rewrite every `http://archive.ubuntu.com/ubuntu` reference to `mirror+file:///etc/apt/ubuntu-mirrors.list` in classic `sources.list` (jammy) and deb822 `ubuntu.sources` (noble).
- Apply the same hardening in both [`docker-new/base.Dockerfile`](https://github.com/autowarefoundation/autoware/blob/4589e0dc29f2147294c02e53da74a51c725f6f5a/docker-new/base.Dockerfile) and [`.github/workflows/setup-universe.yaml`](https://github.com/autowarefoundation/autoware/blob/4589e0dc29f2147294c02e53da74a51c725f6f5a/.github/workflows/setup-universe.yaml), before the first apt call.

## Why

Transient TCP timeouts to `archive.ubuntu.com` have been failing both the docker-new base image build (during ansible's `apt install`) and the self-hosted `setup-universe` GHA job. Retries cover momentary errors; the Azure mirror with `priority:` annotations avoids the `InRelease`/`Packages.gz` version-skew race (`File has unexpected size - Mirror sync in progress?`) that unannotated mirror peers cause during mid-sync, and `azure.archive.ubuntu.com` is an order of magnitude faster for GHA runners (which live inside Azure's network).

---

- First of 6 PRs splitting #7025.

## Test plan

- [ ] Build `ci-base` and inspect the resulting apt config end to end:
  ```bash
  REGISTRY=autoware PLATFORM=amd64 TAG_DATE=$(date +%Y%m%d) TAG_VERSION= TAG_REF= ROS_DISTRO=humble docker buildx bake -f docker-new/docker-bake.hcl ci-base && docker run --rm autoware:base-humble bash -c "cat /etc/apt/apt.conf.d/99-retries && echo --- && cat /etc/apt/ubuntu-mirrors.list && echo --- && grep -rE 'mirror\+file|archive\.ubuntu' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null"
  ```
  Expect: retries=5 with 30s timeouts; mirrorlist with both `priority:` entries; every `http://archive.ubuntu.com/ubuntu` reference rewritten to `mirror+file:///etc/apt/ubuntu-mirrors.list`. `security.ubuntu.com` entries unchanged.
- [ ] Observe `Get:` lines in any later `apt-get update` from that image: URIs should hit `azure.archive.ubuntu.com` exclusively; `archive.ubuntu.com` should appear only on Azure failure.
- [ ] Trigger `setup-universe` on this branch and confirm the new "Configure apt retries and mirror fallback" step runs before `Install dependencies` and the subsequent `apt-get update` succeeds.