### PR TITLE
ci: gate setup-universe behind run:health-check, unify label reusable

### DIFF
--- a/.github/workflows/health-check.yaml
+++ b/.github/workflows/health-check.yaml
@@ -16,14 +16,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  label-check:
-    uses: autowarefoundation/autoware-github-actions/.github/workflows/make-sure-label-is-present.yaml@v1
+  require-label:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/require-label.yaml@v1
     with:
       label: run:health-check
 
   docker-build:
-    needs: label-check
-    if: ${{ needs.label-check.outputs.result == 'true' ||
+    needs: require-label
+    if: ${{ needs.require-label.outputs.result == 'true' ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' }}
     strategy:

--- a/.github/workflows/setup-universe.yaml
+++ b/.github/workflows/setup-universe.yaml
@@ -2,13 +2,25 @@ name: setup-universe
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  require-label:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/require-label.yaml@v1
+    with:
+      label: run:health-check
+
   setup-universe:
+    needs: require-label
+    if: ${{ needs.require-label.outputs.result == 'true' }}
     runs-on: [self-hosted, Linux, X64]
     strategy:
       fail-fast: false


### PR DESCRIPTION
- **Parent Issue:** #6852
- Gate [`setup-universe`](https://github.com/autowarefoundation/autoware/blob/3f0d5c930de1e69db4debfe5876cae42894761e9/.github/workflows/setup-universe.yaml) behind the `run:health-check` label: add a `require-label` job plus `needs:` / `if:` on the existing `setup-universe` job, and add `pull_request.types` (`opened`, `synchronize`, `reopened`, `labeled`) so the workflow re-triggers when the label is added mid-review.
- Switch [`health-check.yaml`](https://github.com/autowarefoundation/autoware/blob/3f0d5c930de1e69db4debfe5876cae42894761e9/.github/workflows/health-check.yaml) from `make-sure-label-is-present.yaml@v1` to `require-label.yaml@v1` (job renamed `label-check` → `require-label`).

## Why

`setup-universe` runs `setup-dev-env.sh` on a self-hosted runner and consumes meaningful time on every PR. It only needs to run for infrastructure-touching PRs — the same gate `health-check` already uses. A single `run:health-check` label now toggles both heavyweight pre-merge checks. Switching both callers to `require-label.yaml@v1` aligns with the sub-repo build-and-test workflows and surfaces missing labels as red status rather than silent skips.

---

- 2 of 6 PRs splitting #7025. Builds on #7028 (merged).

## Test plan

- [ ] Open a PR touching `.github/workflows/setup-universe.yaml` without the `run:health-check` label. Expect the `require-label` job red and `setup-universe` skipped.
- [ ] Add the `run:health-check` label to that PR. Expect `require-label` green and `setup-universe` to proceed through to `Run setup script`.
- [ ] Trigger `health-check` via `schedule` or `workflow_dispatch` with no label. Expect `require-label` skipped but `docker-build` still running because the `if:` admits `schedule`/`workflow_dispatch`.