### PR TITLE
ci(health-check): rewire cache to match docker-new restructure

### DIFF
--- a/.github/workflows/health-check-reusable.yaml
+++ b/.github/workflows/health-check-reusable.yaml
@@ -29,6 +29,10 @@ jobs:
       - name: 📥 Check out repository
         uses: actions/checkout@v6
 
+      - name: 🏷️ Compute cache ref
+        id: meta
+        run: echo "ref_name=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+
       - name: 💻 Runner specs
         run: |
           echo "::group::CPU"
@@ -72,6 +76,54 @@ jobs:
             [worker.oci]
               max-parallelism = 2
 
+      # Read-only restore of the BuildKit mount cache populated by the
+      # main docker-new pipeline's `ci-universe` group. Same mount IDs
+      # (apt/ccache/pip/pipx keyed by ROS_DISTRO) as the main build, so
+      # health-check reuses whatever tarball main last saved for this
+      # platform. No cache-save here: health-check does not write back.
+      - name: 💾 Restore BuildKit cache mounts (read-only)
+        id: cache-restore
+        uses: actions/cache/restore@v5
+        with:
+          path: cache-mounts
+          key: buildkit-mounts-ci-universe-humble-${{ matrix.platform }}-${{ github.sha }}
+          restore-keys: |
+            buildkit-mounts-ci-universe-humble-${{ matrix.platform }}-
+
+      - name: 💉 Inject BuildKit cache mounts
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          cache-map: |
+            {
+              "cache-mounts/apt-cache": {
+                "id": "apt-cache-humble",
+                "target": "/var/cache/apt"
+              },
+              "cache-mounts/apt-lists": {
+                "id": "apt-lists-humble",
+                "target": "/var/lib/apt/lists"
+              },
+              "cache-mounts/ccache": {
+                "id": "ccache-humble",
+                "target": "/home/aw/.ccache",
+                "uid": "1000",
+                "gid": "1000"
+              },
+              "cache-mounts/pip": {
+                "id": "pip-cache",
+                "target": "/home/aw/.cache/pip",
+                "uid": "1000",
+                "gid": "1000"
+              },
+              "cache-mounts/pipx": {
+                "id": "pipx-cache",
+                "target": "/home/aw/.cache/pipx",
+                "uid": "1000",
+                "gid": "1000"
+              }
+            }
+          skip-extraction: ${{ steps.cache-restore.outputs.cache-hit }}
+
       - name: 🔑 Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -89,8 +141,9 @@ jobs:
           files: docker-new/docker-bake.hcl
           provenance: false
           set: |
-            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:humble-${{ matrix.platform }}-main
-            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:${{ matrix.build-type }}-humble-${{ matrix.platform }}-main
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:health-check-${{ matrix.build-type }}-humble-${{ matrix.platform }}-${{ steps.meta.outputs.ref_name }}
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:health-check-${{ matrix.build-type }}-humble-${{ matrix.platform }}-main
+            *.cache-to=type=registry,ref=ghcr.io/${{ github.repository }}-buildcache-new:health-check-${{ matrix.build-type }}-humble-${{ matrix.platform }}-${{ steps.meta.outputs.ref_name }},mode=max,ignore-error=true
 
       - name: 📊 Disk space
         if: always()

--- a/.github/workflows/health-check-reusable.yaml
+++ b/.github/workflows/health-check-reusable.yaml
@@ -76,11 +76,7 @@ jobs:
             [worker.oci]
               max-parallelism = 2
 
-      # Read-only restore of the BuildKit mount cache populated by the
-      # main docker-new pipeline's `ci-universe` group. Same mount IDs
-      # (apt/ccache/pip/pipx keyed by ROS_DISTRO) as the main build, so
-      # health-check reuses whatever tarball main last saved for this
-      # platform. No cache-save here: health-check does not write back.
+      # Read-only: reuses the mount cache saved by docker-new's `ci-universe` group.
       - name: 💾 Restore BuildKit cache mounts (read-only)
         id: cache-restore
         uses: actions/cache/restore@v5


### PR DESCRIPTION
- **Parent Issue:** #6852
- Scope the registry cache tags to health-check's own namespace: `health-check-<build-type>-humble-<platform>-<ref>` with `-main` as fallback read and a current-ref write (`mode=max, ignore-error=true`). Mirrors the pattern used by the main `docker-build-new` pipeline.
- Add read-only BuildKit mount cache restore + [`buildkit-cache-dance@v3`](https://github.com/reproducible-containers/buildkit-cache-dance) injection fed by the main pipeline's `buildkit-mounts-ci-universe-humble-<platform>-*` tarballs (apt / apt-lists / ccache / pip / pipx, IDs matched to the main build). Health-check never writes back.
- Compute a sanitized `ref_name` output (replaces `/` with `-`) so branch names like `feat/foo` produce valid registry tags.

## Why

The previous `buildcache-new:humble-<platform>-main` / `buildcache-new:<build-type>-humble-<platform>-main` tags live in the main `docker-build-new` pipeline's registry namespace. Sharing scope meant health-check runs could overwrite each other's or main's entries, and the tag layout didn't reflect the new per-distro / per-arch / per-ref structure. Giving health-check its own `health-check-*` prefix keeps caches isolated; read-only mount restore lets health-check warm apt/ccache/pip/pipx from tarballs main already paid to produce.

---

- 4 of 6 PRs splitting #7025. Builds on #7030 (merged).
- The `buildkit-mounts-ci-universe-humble-<platform>-*` tarballs that this reads are produced by the main `docker-build-new` pipeline. Until the next PR in the stack (docker-new restructure) lands, those tarballs don't exist and `cache-restore` will stay a miss — benign, just no mount reuse.

## Test plan

- [ ] Trigger a health-check PR run (`run:health-check` label). Confirm the `🔨 Build Autoware` step's `set:` block references the new scope: `ghcr.io/<repo>-buildcache-new:health-check-<build-type>-humble-<platform>-<ref_name>` (cache-from + cache-to) plus `health-check-*-main` (cache-from fallback).
- [ ] Confirm the `💾 Restore BuildKit cache mounts (read-only)` step runs and logs either `Cache restored from key: buildkit-mounts-ci-universe-humble-<platform>-...` (hit) or `Cache not found` (miss — expected before PR 5 lands).
- [ ] Confirm the `💉 Inject BuildKit cache mounts` step completes without error even on a miss (inject tolerates empty `cache-mounts/`).
- [ ] Dispatch `health-check` from the Actions UI and verify the cache-to write lands: `docker manifest inspect ghcr.io/<repo>-buildcache-new:health-check-main-humble-amd64-main` should resolve after the run.