### PR TITLE
feat(docker): drive CMAKE_CUDA_ARCHITECTURES per ROS_DISTRO

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -45,6 +45,17 @@ graph TB
 | `universe`                   | Runtime image with compiled autoware (no CUDA)                                        | Deployment without GPU                                     |
 | `universe-cuda`              | Runtime image with compiled autoware, inherits CUDA runtime from `base-cuda-runtime`  | Deployment with GPU                                        |
 
+## CUDA architecture support
+
+CUDA-bearing images (`base-cuda-*`, `universe-*-cuda`) are built for both `linux/amd64` and `linux/arm64`. The arm64 variant follows the SBSA flavor of CUDA:
+
+| ROS distro | Ubuntu | CUDA | `CMAKE_CUDA_ARCHITECTURES`                          |
+| ---------- | ------ | ---- | --------------------------------------------------- |
+| jazzy      | 24.04  | 13.0 | `86;87;89;90;110` (includes Thor sm_110)            |
+| humble     | 22.04  | 12.8 | `86;89;90` (sm_110 omitted — Thor needs CUDA 13.0+) |
+
+The arm64 SBSA variant has been runtime-verified on NVIDIA Thor (Jetson Thor on JetPack 7) for `jazzy`. The image is expected to also work on other Arm + NVIDIA-dGPU combinations that follow the standard SBSA stack — Ampere Altra + dGPU, Grace+Hopper / GH200, System76 ARM workstations, AWS Graviton + GPU — but these have not been individually verified. **NVIDIA Jetson Orin** (JetPack 6 / L4T Tegra CUDA 12.x) is **not** supported by the SBSA stack and remains out of scope; an L4T-derived image variant would be needed.
+
 ## Pull from GHCR
 
 Pre-built multi-arch images (amd64 + arm64) are available on GHCR:
@@ -99,6 +110,9 @@ docker buildx bake -f docker/docker-bake.hcl universe-cuda
 
 # Build for humble
 ROS_DISTRO=humble docker buildx bake -f docker/docker-bake.hcl base
+
+# Cross-build arm64 CUDA image on an amd64 host (slow; CI is recommended)
+docker buildx bake -f docker/docker-bake.hcl universe-cuda --set "*.platform=linux/arm64"
 ```
 
 ## Usage

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # Run Autoware in Docker
 
-<!-- cspell:ignore libcuda libcudart ctypes CDLL byref prereq tegrastats NVDEC NVENC -->
+<!-- cspell:ignore libcuda libcudart ctypes CDLL byref prereq tegrastats NVDEC NVENC Altra -->
 
 ## Image Graph
 
@@ -47,9 +47,11 @@ graph TB
 
 ## CUDA architecture support
 
-CUDA-bearing images (`base-cuda-*`, `universe-*-cuda`) are built for both `linux/amd64` and `linux/arm64`. The arm64 variant follows the SBSA flavor of CUDA:
+All CUDA-bearing images (`base-cuda-*`, `universe-*-cuda`) are built for both `linux/amd64` and `linux/arm64`, with the arm64 variant following the SBSA flavor of CUDA.
 
-| ROS distro | Ubuntu | CUDA | `CMAKE_CUDA_ARCHITECTURES`                          |
+The `universe-*-cuda` stages compile Autoware's CUDA code, so they bake a `CMAKE_CUDA_ARCHITECTURES` value selected per ROS distro. The `base-cuda-*` images only carry the CUDA runtime/dev libraries and do not set this variable.
+
+| ROS distro | Ubuntu | CUDA | `CMAKE_CUDA_ARCHITECTURES` (`universe-*-cuda`)      |
 | ---------- | ------ | ---- | --------------------------------------------------- |
 | jazzy      | 24.04  | 13.0 | `86;87;89;90;110` (includes Thor sm_110)            |
 | humble     | 22.04  | 12.8 | `86;89;90` (sm_110 omitted — Thor needs CUDA 13.0+) |

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -57,9 +57,14 @@ function "ctx" {
 //
 // Compute capabilities: 86=Ampere consumer, 87=Orin, 89=Ada, 90=Hopper,
 //                       110=Thor Blackwell (Jetson Thor + DRIVE Thor).
-function "cuda_archs" {
+//
+// Unknown distros resolve to "" on purpose: an empty CMAKE_CUDA_ARCHITECTURES
+// fails the CUDA build loudly rather than silently picking one distro's list.
+function "cuda_architectures" {
   params = [distro]
-  result = distro == "jazzy" ? "86;87;89;90;110" : "86;89;90"
+  result = distro == "jazzy" ? "86;87;89;90;110" : (
+    distro == "humble" ? "86;89;90" : ""
+  )
 }
 
 group "default" {
@@ -206,7 +211,7 @@ target "_universe-cuda-base" {
     BASE_CUDA_RUNTIME_IMAGE = "autoware-base-cuda-runtime"
     BASE_CUDA_DEVEL_IMAGE   = "autoware-base-cuda-devel"
     ROS_DISTRO              = ROS_DISTRO
-    CUDA_ARCHITECTURES      = cuda_archs(ROS_DISTRO)
+    CUDA_ARCHITECTURES      = cuda_architectures(ROS_DISTRO)
   }
 }
 

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -46,6 +46,22 @@ function "ctx" {
   result = USE_REGISTRY_CONTEXTS ? "docker-image://${tags(name)[0]}" : "target:${name}"
 }
 
+// CUDA architectures by ROS_DISTRO. The same value drives both
+// CMAKE_CUDA_ARCHITECTURES env vars in docker/universe-cuda.Dockerfile.
+//
+//   jazzy  (Ubuntu 24.04 / CUDA 13.0): include sm_110 (Thor Blackwell)
+//   humble (Ubuntu 22.04 / CUDA 12.8): omit sm_110 — Thor's compute
+//                                       capability was introduced in
+//                                       CUDA 13.0 and is not a valid
+//                                       target for the 12.8 toolchain.
+//
+// Compute capabilities: 86=Ampere consumer, 87=Orin, 89=Ada, 90=Hopper,
+//                       110=Thor Blackwell (Jetson Thor + DRIVE Thor).
+function "cuda_archs" {
+  params = [distro]
+  result = distro == "jazzy" ? "86;87;89;90;110" : "86;89;90"
+}
+
 group "default" {
   targets = ["base",
              "core-dependencies", "core-devel", "core",
@@ -190,6 +206,7 @@ target "_universe-cuda-base" {
     BASE_CUDA_RUNTIME_IMAGE = "autoware-base-cuda-runtime"
     BASE_CUDA_DEVEL_IMAGE   = "autoware-base-cuda-devel"
     ROS_DISTRO              = ROS_DISTRO
+    CUDA_ARCHITECTURES      = cuda_archs(ROS_DISTRO)
   }
 }
 

--- a/docker/universe-cuda.Dockerfile
+++ b/docker/universe-cuda.Dockerfile
@@ -32,8 +32,8 @@ ENV CCACHE_DIR="/home/aw/.ccache"
 ENV CMAKE_PREFIX_PATH="/opt/acados${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
 ENV ACADOS_SOURCE_DIR="/opt/acados"
 ENV LD_LIBRARY_PATH="/opt/acados/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-# Compute capabilities: 86=Ampere consumer, 87=Orin, 89=Ada, 90=Hopper, 110=Thor Blackwell (Jetson Thor + DRIVE Thor).
-ENV CMAKE_CUDA_ARCHITECTURES="86;87;89;90;110"
+ARG CUDA_ARCHITECTURES
+ENV CMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES}
 
 # hadolint ignore=DL3022
 COPY --from=autoware-core-devel /opt/autoware /opt/autoware
@@ -83,6 +83,7 @@ RUN --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=
 
 FROM ${BASE_CUDA_RUNTIME_IMAGE} AS universe-cuda
 ARG ROS_DISTRO
+ARG CUDA_ARCHITECTURES
 ENV AUTOWARE_RUNTIME=1
 
 USER ${USERNAME}
@@ -123,4 +124,4 @@ RUN find /opt/autoware -name '*.so' -exec strip --strip-unneeded {} +
 ENV CMAKE_PREFIX_PATH="/opt/acados${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
 ENV ACADOS_SOURCE_DIR="/opt/acados"
 ENV LD_LIBRARY_PATH="/opt/acados/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-ENV CMAKE_CUDA_ARCHITECTURES="86;87;89;90;110"
+ENV CMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES}

--- a/docker/universe-cuda.Dockerfile
+++ b/docker/universe-cuda.Dockerfile
@@ -32,7 +32,10 @@ ENV CCACHE_DIR="/home/aw/.ccache"
 ENV CMAKE_PREFIX_PATH="/opt/acados${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
 ENV ACADOS_SOURCE_DIR="/opt/acados"
 ENV LD_LIBRARY_PATH="/opt/acados/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-ARG CUDA_ARCHITECTURES
+# Default to the full jazzy/CUDA 13 list so a direct `docker build` without
+# the build-arg still yields a usable image; docker-bake.hcl always overrides
+# this with the per-distro value from cuda_architectures().
+ARG CUDA_ARCHITECTURES="86;87;89;90;110"
 ENV CMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES}
 
 # hadolint ignore=DL3022
@@ -83,7 +86,9 @@ RUN --mount=type=cache,id=apt-cache-${ROS_DISTRO},target=/var/cache/apt,sharing=
 
 FROM ${BASE_CUDA_RUNTIME_IMAGE} AS universe-cuda
 ARG ROS_DISTRO
-ARG CUDA_ARCHITECTURES
+# See the universe-dependencies-cuda stage: default keeps a direct
+# `docker build` usable; docker-bake.hcl overrides it per ROS distro.
+ARG CUDA_ARCHITECTURES="86;87;89;90;110"
 ENV AUTOWARE_RUNTIME=1
 
 USER ${USERNAME}


### PR DESCRIPTION
## Description

The `humble` and `jazzy` CUDA images both hard-coded
`CMAKE_CUDA_ARCHITECTURES="86;87;89;90;110"` in `docker/universe-cuda.Dockerfile`.
The `sm_110` entry targets NVIDIA Thor (Blackwell), whose compute capability
was introduced in CUDA 13.0. On `humble` (Ubuntu 22.04 / CUDA 12.8) `sm_110`
is not a valid target for the toolchain, so `humble` images advertised an
architecture they cannot meaningfully build for.

This change drives the architecture list per ROS distro:

- Adds a `cuda_archs()` HCL function in `docker/docker-bake.hcl` returning
  `86;87;89;90;110` for `jazzy` (CUDA 13.0, includes Thor `sm_110`) and
  `86;89;90` for `humble` (CUDA 12.8). The value flows as the
  `CUDA_ARCHITECTURES` build-arg through `_universe-cuda-base` into every
  CUDA-bearing universe stage.
- Replaces the two hard-coded `ENV CMAKE_CUDA_ARCHITECTURES="86;87;89;90;110"`
  lines in `docker/universe-cuda.Dockerfile` with `ARG CUDA_ARCHITECTURES` +
  `ENV CMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES}` in both the
  `universe-dependencies-cuda` and `universe-cuda` stages.
- Documents the per-distro arch sets, the supported arm64 SBSA hosts, and the
  Jetson Orin out-of-scope caveat in `docker/README.md`.

No CI workflow change is required: `docker-build-and-push` already builds all
12 bake targets for both `amd64` and `arm64` across both distros and stitches
them into multi-arch manifests.

## How was this PR tested?

Ran the full `docker-build-and-push` pipeline on a fork. All 12 bake targets
built for both `amd64` and `arm64` across `humble` and `jazzy` and stitched
into multi-arch manifests.

Verified GitHub Actions run:
https://github.com/youtalk/autoware/actions/runs/26267312613

Inspecting the resulting images confirmed the per-distro split:

- `universe-{dependencies,devel,}-cuda-humble` (amd64 + arm64) →
  `CMAKE_CUDA_ARCHITECTURES=86;89;90`
- `universe-{dependencies,devel,}-cuda-jazzy` (amd64 + arm64) →
  `CMAKE_CUDA_ARCHITECTURES=86;87;89;90;110`

`docker buildx bake --print` was also used to confirm `cuda_archs()` resolves
to `86;89;90` for `humble` and `86;87;89;90;110` for `jazzy`.
