### PR TITLE
fix(ansible): call pipx directly instead of community.general.pipx module

### DIFF
--- a/ansible/roles/dev_tools/tasks/main.yaml
+++ b/ansible/roles/dev_tools/tasks/main.yaml
@@ -22,14 +22,14 @@
     update_cache: true
 
 - name: Install pre-commit
-  community.general.pipx:
-    name: pre-commit
-    executable: /usr/bin/pipx
+  ansible.builtin.command:
+    cmd: /usr/bin/pipx install pre-commit
+    creates: ~/.local/bin/pre-commit
 
 - name: Install clang-format
-  community.general.pipx:
-    name: clang-format
-    executable: /usr/bin/pipx
+  ansible.builtin.command:
+    cmd: /usr/bin/pipx install clang-format
+    creates: ~/.local/bin/clang-format
 
 - name: Install Go
   become: true

--- a/ansible/roles/huggingface_cli/tasks/main.yaml
+++ b/ansible/roles/huggingface_cli/tasks/main.yaml
@@ -12,6 +12,6 @@
   when: not huggingface_cli__pipx.stat.exists
 
 - name: Install huggingface_hub for the hf CLI
-  community.general.pipx:
-    name: huggingface_hub
-    executable: /usr/bin/pipx
+  ansible.builtin.command:
+    cmd: /usr/bin/pipx install huggingface_hub
+    creates: ~/.local/bin/hf


### PR DESCRIPTION
## Description

Running the dev-env playbook fails on the pipx-based roles when the local Ansible is newer than the `ansible==10.*` pinned in `ansible/scripts/install-ansible.sh`:

```text
TASK [autoware.dev_env.huggingface_cli : Install huggingface_hub for the hf CLI]
fatal: [localhost]: FAILED! => ... "msg": "The pipx tool must be at least at version 1.7.0" ... "version": "1.4.3"
```

### How to reproduce

On a plain Ubuntu 24.04 machine:

```bash
# 1. Install pipx from apt (this is what our roles and install-ansible.sh do): you get pipx 1.4.3
sudo apt update && sudo apt install -y pipx

# 2. Install any recent ansible instead of the pinned ansible==10.*
#    (ansible >= 12 bundles community.general >= 11)
pipx install --include-deps --force "ansible==14.*"

# 3. Install the collection and run any role that uses community.general.pipx
cd autoware
ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
ansible-playbook autoware.dev_env.install_dev_env --tags artifacts -e "data_dir=$HOME/autoware_data" --ask-become-pass
```

The `Install huggingface_hub for the hf CLI` task fails with the error above. The same happens in the `dev_tools` role.

### Root cause

- Since [community.general 11.0.0](https://github.com/ansible-collections/community.general/releases/tag/11.0.0), the [community.general.pipx module](https://docs.ansible.com/projects/ansible/latest/collections/community/general/pipx_module.html) requires pipx >= 1.7.0.
- **Ubuntu 24.04 ships pipx 1.4.3** in apt and 22.04 ships even older, with no upgrade path for the lifetime of either LTS (pipx 1.7.0 was released after the noble archive froze).
- ❌ Upstream's recommended workaround is installing pipx from PyPI via `ansible.builtin.pip`, which collides with PEP 668 (externally managed system Python) on 24.04 and would replace our clean apt-based bootstrap with a pip/venv layer.

Since the module's only job here is running `pipx install`, this PR drops the module dependency and calls pipx directly:

- **fix(ansible):** replace `community.general.pipx` with `ansible.builtin.command: pipx install <pkg>` guarded by `creates:` in the `huggingface_cli` and `dev_tools` (pre-commit, clang-format) roles.

This works with any pipx and any community.general version, on both 22.04 and 24.04, and removes the coupling between the playbook and whatever Ansible version the user happens to have installed.

## How was this PR tested?

On Ubuntu 24.04 with ansible 14.1.0 (community.general 13.1.0, the combination that previously failed):

- `ansible-playbook --syntax-check` on `install_dev_env.yaml` passes after reinstalling the collection.
- Ran the `huggingface_cli` role with `~/.local/bin/hf` already present: task reports `ok` (skipped via `creates:`), no version error.
- Uninstalled the `huggingface-hub` venv and reran: task reports `changed`, installs hf 1.24.0 with a working `hf version`.
