### PR TITLE
feat(ansible): download bevfusion, camera_streampetr, lidar_transfusion, image_projection_based_fusion from Hugging Face

### DIFF
--- a/ansible/roles/artifacts/README.md
+++ b/ansible/roles/artifacts/README.md
@@ -2,7 +2,7 @@
 
 The Autoware perception stack uses models for inference. These models are downloaded by running `ansible-playbook autoware.dev_env.install_dev_env --tags artifacts`.
 
-The models are hosted by Web.Auto.
+The models are hosted on [Hugging Face](https://huggingface.co/AutowareFoundation) under the `AutowareFoundation` organization. Models that have not been migrated yet are still hosted by Web.Auto.
 
 Default `data_dir` location is `~/autoware_data/ml_models` (part of the asset-typed `~/autoware_data/` layout: `assets/`, `maps/`, `ml_models/`, `recordings/`, `scenarios/`).
 
@@ -68,7 +68,7 @@ This step should be repeated when a new playbook is added.
 ansible-playbook autoware.dev_env.install_dev_env --tags artifacts -e "data_dir=$HOME/autoware_data/ml_models" --ask-become-pass
 ```
 
-This will download and extract the artifacts to the specified directory. Files fetched with `get_url` are validated against checksums pinned in this role; model bundles fetched from Hugging Face are pinned to a version tag and verified by the `hf` CLI during download.
+This will download and extract the artifacts to the specified directory. Files fetched with `get_url` are validated against checksums pinned in this role. Model bundles fetched from Hugging Face are pinned to a version tag instead; their integrity relies on the Hub and the transport, not on checksums pinned here.
 
 ### Migrating from the legacy layout
 

--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -19,98 +19,32 @@
     dest: "{{ data_dir }}/yabloc_pose_initializer/"
 
 # bevfusion
-- name: Create bevfusion directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/bevfusion"
-    mode: "755"
-    state: directory
+- name: Download bevfusion model bundle ({{ revision }})
+  vars:
+    revision: v2.0
+  ansible.builtin.command:
+    cmd: >-
+      hf download AutowareFoundation/bevfusion
+      --revision {{ revision }}
+      --local-dir {{ data_dir }}/bevfusion
+  environment:
+    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
+    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
+  changed_when: false
 
-- name: Download bevfusion/bevfusion_lidar.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/bevfusion/t4base_120m/v2/bevfusion_lidar.onnx
-    dest: "{{ data_dir }}/bevfusion/bevfusion_lidar.onnx"
-    mode: "644"
-    checksum: sha256:5c29087963bf2c4dc02bf45c29d459303be602d63f9b6adff22a75c9cfb459a6
-
-- name: Download bevfusion/bevfusion_camera_lidar.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/bevfusion/t4base_120m/v2/bevfusion_camera_lidar.onnx
-    dest: "{{ data_dir }}/bevfusion/bevfusion_camera_lidar.onnx"
-    mode: "644"
-    checksum: sha256:aa78d2f219146cb1423287643bbef81666d429ddcde4432a2e51db3f212a7c68
-
-- name: Download bevfusion/bevfusion_image_backbone.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/bevfusion/t4base_120m/v2/bevfusion_image_backbone.onnx
-    dest: "{{ data_dir }}/bevfusion/bevfusion_image_backbone.onnx"
-    mode: "644"
-    checksum: sha256:799af1e486b5c1245c8e2783bc77522d49e4a6535320ae77eba1b0f829385797
-
-- name: Download bevfusion/ml_package_bevfusion_lidar.param.yaml
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/bevfusion/t4base_120m/v2/ml_package_bevfusion_lidar.param.yaml
-    dest: "{{ data_dir }}/bevfusion/ml_package_bevfusion_lidar.param.yaml"
-    mode: "644"
-    checksum: sha256:866265b9f0fc8c17805c0974339d3c7c4e601c1aa212818971fc650d71782181
-
-- name: Download bevfusion/ml_package_bevfusion_camera_lidar.param.yaml
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/bevfusion/t4base_120m/v2/ml_package_bevfusion_camera_lidar.param.yaml
-    dest: "{{ data_dir }}/bevfusion/ml_package_bevfusion_camera_lidar.param.yaml"
-    mode: "644"
-    checksum: sha256:50707efcbb7fa80527d0a2effe677557d0be5df5cd72276f9af152399f27c719
-
-- name: Download bevfusion/detection_class_remapper.param.yaml
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/bevfusion/t4base_120m/v2/detection_class_remapper.param.yaml
-    dest: "{{ data_dir }}/bevfusion/detection_class_remapper.param.yaml"
-    mode: "644"
-    checksum: sha256:928f9eb14ac042d725909f12b2be1532c16b09a683485c5936cf04fb04728520
-
-# streampetr
-- name: Create camera_streampetr directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/camera_streampetr"
-    mode: "755"
-    state: directory
-
-- name: Download camera_streampetr/simplify_pts_head_memory.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/streampetr/v1/simplify_pts_head_memory.onnx
-    dest: "{{ data_dir }}/camera_streampetr/simplify_pts_head_memory.onnx"
-    mode: "644"
-    checksum: sha256:49b038bd280a1a4ee4f9e244d6e7315eb9c6f7b6f93e27717d9c21cb4d374015
-
-- name: Download camera_streampetr/simplify_position_embedding.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/streampetr/v1/simplify_position_embedding.onnx
-    dest: "{{ data_dir }}/camera_streampetr/simplify_position_embedding.onnx"
-    mode: "644"
-    checksum: sha256:629f14820cb8288659598f6c056c2f6cebe8df3758f1567e74fd1fb3c0f67163
-
-- name: Download camera_streampetr/simplify_extract_img_feat.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/streampetr/v1/simplify_extract_img_feat.onnx
-    dest: "{{ data_dir }}/camera_streampetr/simplify_extract_img_feat.onnx"
-    mode: "644"
-    checksum: sha256:322c2f426f9a01c43d28456f50b33f0fa2039535cf50db7329483097cd363efd
-
-- name: Download camera_streampetr/ml_package_camera_streampetr.param.yaml
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/streampetr/v1/ml_package_camera_streampetr.param.yaml
-    dest: "{{ data_dir }}/camera_streampetr/ml_package_camera_streampetr.param.yaml"
-    mode: "644"
-    checksum: sha256:f539407f0b3aee65f7d6d30401dd0052dfed86fa7beefef86c79061362615218
+# camera_streampetr
+- name: Download camera_streampetr model bundle ({{ revision }})
+  vars:
+    revision: v1.0
+  ansible.builtin.command:
+    cmd: >-
+      hf download AutowareFoundation/camera_streampetr
+      --revision {{ revision }}
+      --local-dir {{ data_dir }}/camera_streampetr
+  environment:
+    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
+    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
+  changed_when: false
 
 # bevdet
 - name: Create tensorrt_bevdet directory inside {{ data_dir }}
@@ -133,41 +67,19 @@
     dest: "{{ data_dir }}/tensorrt_bevdet/"
 
 # image_projection_based_fusion
-- name: Create image_projection_based_fusion directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/image_projection_based_fusion"
-    mode: "755"
-    state: directory
+- name: Download image_projection_based_fusion model bundle ({{ revision }})
+  vars:
+    revision: v5.0
+  ansible.builtin.command:
+    cmd: >-
+      hf download AutowareFoundation/image_projection_based_fusion
+      --revision {{ revision }}
+      --local-dir {{ data_dir }}/image_projection_based_fusion
+  environment:
+    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
+    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
+  changed_when: false
 
-- name: Download image_projection_based_fusion/pts_voxel_encoder_pointpainting.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/pointpainting/v5/pts_voxel_encoder_pointpainting.onnx
-    dest: "{{ data_dir }}/image_projection_based_fusion/pts_voxel_encoder_pointpainting.onnx"
-    mode: "644"
-    checksum: sha256:3ca452ea5ca9467bf782955f75704ba8466841e275e8b8acd991b9911d53249e
-
-- name: Download image_projection_based_fusion/pts_backbone_neck_head_pointpainting.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/pointpainting/v5/pts_backbone_neck_head_pointpainting.onnx
-    dest: "{{ data_dir }}/image_projection_based_fusion/pts_backbone_neck_head_pointpainting.onnx"
-    mode: "644"
-    checksum: sha256:7fe62fcebe0e0f62a000d06aa94d779feb444d933671a4a3189fe01be8c19a00
-- name: Download image_projection_based_fusion/detection_class_remapper.param.yaml
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/pointpainting/v5/detection_class_remapper.param.yaml
-    dest: "{{ data_dir }}/image_projection_based_fusion/detection_class_remapper.param.yaml"
-    mode: "644"
-    checksum: sha256:c711f8875ece9b527dfe31ffc75f8c0de2e77945ef67860a959a4e04c36772d5
-- name: Download image_projection_based_fusion/pointpainting_ml_package.param.yaml
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/pointpainting/v5/pointpainting_ml_package.param.yaml
-    dest: "{{ data_dir }}/image_projection_based_fusion/pointpainting_ml_package.param.yaml"
-    mode: "644"
-    checksum: sha256:a70f8a01d592aa4e85d481d44377f37ea35ea5271c064723d6d0db7d375990a3
 # lidar_apollo_instance_segmentation
 - name: Create lidar_apollo_instance_segmentation directory inside {{ data_dir }}
   ansible.builtin.file:
@@ -214,35 +126,18 @@
   changed_when: false
 
 # lidar_transfusion
-- name: Create lidar_transfusion directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/lidar_transfusion"
-    mode: "755"
-    state: directory
-
-- name: Download lidar_transfusion/transfusion.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/transfusion/t4xx1_90m/v2.1/transfusion.onnx
-    dest: "{{ data_dir }}/lidar_transfusion/transfusion.onnx"
-    mode: "644"
-    checksum: sha256:1d8f0ee6d59ccc3cca914f9892f6ac8f0a9e35082abb91da183c00e3e2c2718a
-
-- name: Download lidar_transfusion/transfusion_ml_package.param.yaml
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/transfusion/t4xx1_90m/v2.1/transfusion_ml_package.param.yaml
-    dest: "{{ data_dir }}/lidar_transfusion/transfusion_ml_package.param.yaml"
-    mode: "644"
-    checksum: sha256:476f7727adc17a823962f2e09ba23d40f3116c50be48361d98179d054cd131b6
-
-- name: Download lidar_transfusion/detection_class_remapper.param.yaml
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/transfusion/t4xx1_90m/v2.1/detection_class_remapper.param.yaml
-    dest: "{{ data_dir }}/lidar_transfusion/detection_class_remapper.param.yaml"
-    mode: "644"
-    checksum: sha256:c711f8875ece9b527dfe31ffc75f8c0de2e77945ef67860a959a4e04c36772d5
+- name: Download lidar_transfusion model bundle ({{ revision }})
+  vars:
+    revision: v2.1
+  ansible.builtin.command:
+    cmd: >-
+      hf download AutowareFoundation/lidar_transfusion
+      --revision {{ revision }}
+      --local-dir {{ data_dir }}/lidar_transfusion
+  environment:
+    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
+    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
+  changed_when: false
 
 # tensorrt_yolox
 - name: Create tensorrt_yolox directory inside {{ data_dir }}

--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -26,7 +26,7 @@
     cmd: >-
       hf download AutowareFoundation/bevfusion
       --revision {{ revision }}
-      --local-dir {{ data_dir }}/bevfusion
+      --local-dir "{{ data_dir }}/bevfusion"
   environment:
     PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
     HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
@@ -40,7 +40,7 @@
     cmd: >-
       hf download AutowareFoundation/camera_streampetr
       --revision {{ revision }}
-      --local-dir {{ data_dir }}/camera_streampetr
+      --local-dir "{{ data_dir }}/camera_streampetr"
   environment:
     PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
     HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
@@ -74,7 +74,7 @@
     cmd: >-
       hf download AutowareFoundation/image_projection_based_fusion
       --revision {{ revision }}
-      --local-dir {{ data_dir }}/image_projection_based_fusion
+      --local-dir "{{ data_dir }}/image_projection_based_fusion"
   environment:
     PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
     HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
@@ -119,7 +119,7 @@
     cmd: >-
       hf download AutowareFoundation/lidar_centerpoint
       --revision {{ revision }}
-      --local-dir {{ data_dir }}/lidar_centerpoint
+      --local-dir "{{ data_dir }}/lidar_centerpoint"
   environment:
     PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
     HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
@@ -133,7 +133,7 @@
     cmd: >-
       hf download AutowareFoundation/lidar_transfusion
       --revision {{ revision }}
-      --local-dir {{ data_dir }}/lidar_transfusion
+      --local-dir "{{ data_dir }}/lidar_transfusion"
   environment:
     PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
     HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
@@ -564,7 +564,7 @@
     cmd: >-
       hf download AutowareFoundation/simpl_prediction
       --revision {{ revision }}
-      --local-dir {{ data_dir }}/simpl_prediction
+      --local-dir "{{ data_dir }}/simpl_prediction"
   environment:
     PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
     HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
@@ -578,7 +578,7 @@
     cmd: >-
       hf download AutowareFoundation/ptv3
       --revision {{ revision }}
-      --local-dir {{ data_dir }}/ptv3
+      --local-dir "{{ data_dir }}/ptv3"
   environment:
     PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
     HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
@@ -592,7 +592,7 @@
     cmd: >-
       hf download AutowareFoundation/lidar_frnet
       --revision {{ revision }}
-      --local-dir {{ data_dir }}/lidar_frnet
+      --local-dir "{{ data_dir }}/lidar_frnet"
   environment:
     PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
     HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
@@ -606,7 +606,7 @@
     cmd: >-
       hf download AutowareFoundation/calibration_status_classifier
       --revision {{ revision }}
-      --local-dir {{ data_dir }}/calibration_status_classifier
+      --local-dir "{{ data_dir }}/calibration_status_classifier"
   environment:
     PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
     HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"


### PR DESCRIPTION
## Description

- Batch B of the artifact hosting migration (#7223). Replaces the per-file `get_url` tasks of four 3D-detection models with one pinned `hf download` task each, following the `lidar_centerpoint` pattern used by batch A (#7224).

| Model | Revision | Replaces |
| --- | --- | --- |
| [`bevfusion`](https://huggingface.co/AutowareFoundation/bevfusion) | `v2.0` | `bevfusion/t4base_120m/v2` |
| [`camera_streampetr`](https://huggingface.co/AutowareFoundation/camera_streampetr) | `v1.0` | `streampetr/v1` |
| [`lidar_transfusion`](https://huggingface.co/AutowareFoundation/lidar_transfusion) | `v2.1` | `transfusion/t4xx1_90m/v2.1` |
| [`image_projection_based_fusion`](https://huggingface.co/AutowareFoundation/image_projection_based_fusion) | `v5.0` | `pointpainting/v5` |

Destination directories and filenames are unchanged, so launch files need no update. All 17 files were verified sha256-identical to the pins being removed.

Two smaller commits are kept separate so the migration commit stays a clean diff against batch A:

- `docs(ansible)`: the README claimed all models are hosted by Web.Auto, and overstated the Hugging Face integrity guarantee.
- `fix(ansible)`: quote `--local-dir` in all `hf download` tasks. `ansible.builtin.command` splits `cmd` with `shlex`, so an unquoted path breaks apart if `data_dir` contains a space.

Known trade-off: the migrated tasks drop `become: true`, so files are now owned by the invoking user instead of root, and existing installs re-download these four models once (~770 MB).

## How to validate manually

### 1. Check out the branch

```bash
cd ~/projects/autoware
gh pr checkout 7229
```

### 2. Install the artifacts

```bash
ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
ansible-playbook autoware.dev_env.install_dev_env --tags artifacts \
  -e "data_dir=$HOME/autoware_data/ml_models" --ask-become-pass
```

`--ask-become-pass` is still needed because the not-yet-migrated models use `get_url` with `become`.

Expect the four tasks named `Download <model> model bundle (vX.Y)` to report `ok`, and the recap to show `failed=0`.

### 3. Verify every delivered file matches the checksums this PR removes

```bash
cd "$HOME/autoware_data/ml_models" && sha256sum -c <<'EOF'
5c29087963bf2c4dc02bf45c29d459303be602d63f9b6adff22a75c9cfb459a6  bevfusion/bevfusion_lidar.onnx
aa78d2f219146cb1423287643bbef81666d429ddcde4432a2e51db3f212a7c68  bevfusion/bevfusion_camera_lidar.onnx
799af1e486b5c1245c8e2783bc77522d49e4a6535320ae77eba1b0f829385797  bevfusion/bevfusion_image_backbone.onnx
866265b9f0fc8c17805c0974339d3c7c4e601c1aa212818971fc650d71782181  bevfusion/ml_package_bevfusion_lidar.param.yaml
50707efcbb7fa80527d0a2effe677557d0be5df5cd72276f9af152399f27c719  bevfusion/ml_package_bevfusion_camera_lidar.param.yaml
928f9eb14ac042d725909f12b2be1532c16b09a683485c5936cf04fb04728520  bevfusion/detection_class_remapper.param.yaml
49b038bd280a1a4ee4f9e244d6e7315eb9c6f7b6f93e27717d9c21cb4d374015  camera_streampetr/simplify_pts_head_memory.onnx
629f14820cb8288659598f6c056c2f6cebe8df3758f1567e74fd1fb3c0f67163  camera_streampetr/simplify_position_embedding.onnx
322c2f426f9a01c43d28456f50b33f0fa2039535cf50db7329483097cd363efd  camera_streampetr/simplify_extract_img_feat.onnx
f539407f0b3aee65f7d6d30401dd0052dfed86fa7beefef86c79061362615218  camera_streampetr/ml_package_camera_streampetr.param.yaml
1d8f0ee6d59ccc3cca914f9892f6ac8f0a9e35082abb91da183c00e3e2c2718a  lidar_transfusion/transfusion.onnx
476f7727adc17a823962f2e09ba23d40f3116c50be48361d98179d054cd131b6  lidar_transfusion/transfusion_ml_package.param.yaml
c711f8875ece9b527dfe31ffc75f8c0de2e77945ef67860a959a4e04c36772d5  lidar_transfusion/detection_class_remapper.param.yaml
3ca452ea5ca9467bf782955f75704ba8466841e275e8b8acd991b9911d53249e  image_projection_based_fusion/pts_voxel_encoder_pointpainting.onnx
7fe62fcebe0e0f62a000d06aa94d779feb444d933671a4a3189fe01be8c19a00  image_projection_based_fusion/pts_backbone_neck_head_pointpainting.onnx
a70f8a01d592aa4e85d481d44377f37ea35ea5271c064723d6d0db7d375990a3  image_projection_based_fusion/pointpainting_ml_package.param.yaml
c711f8875ece9b527dfe31ffc75f8c0de2e77945ef67860a959a4e04c36772d5  image_projection_based_fusion/detection_class_remapper.param.yaml
EOF
```

All 17 lines must print `OK`.

### 4. Confirm re-running is cheap and non-destructive

```bash
ansible-playbook autoware.dev_env.install_dev_env --tags artifacts \
  -e "data_dir=$HOME/autoware_data/ml_models" --ask-become-pass
```

The four tasks should finish in seconds. They always report `ok` (`changed_when: false`), so judge by elapsed time, not by the recap.

### 5. Verify the `--local-dir` quoting fix

Cheap check, no large download:

```bash
hf download AutowareFoundation/image_projection_based_fusion --revision v5.0 \
  --dry-run --local-dir "/tmp/with space/ipbf"
```

Should exit 0. Without the quoting fix the path splits at the space and `hf` receives a truncated destination plus a stray positional argument.

### 6. Lint

```bash
pipx run --spec 'ansible-lint==26.6.0' ansible-lint ansible/roles/artifacts/
pre-commit run --files ansible/roles/artifacts/tasks/main.yaml ansible/roles/artifacts/README.md
```

Both should pass.

## CI

`install-artifacts` (label `run:health-check`) exercises all of the above on a clean runner and reports the total artifacts size, which should stay at 3.90 GB.

---

**AI usage:** written with Claude Code in an interactive session; I set the batch scope and the task pattern to follow.
**Self-review:** done. Reviewed the diff myself and ran a clean-context agent review. The two follow-up commits above came out of it, along with items now tracked in #7223.
**Verification:** all 17 delivered files sha256-matched against the removed pins, cross-checked independently against the Hugging Face API.
