### PR TITLE
feat(ansible): download yabloc_pose_initializer, tensorrt_bevdet, lidar_apollo_instance_segmentation from Hugging Face

### DIFF
--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -1,22 +1,18 @@
 # yabloc_pose_initializer
-- name: Create yabloc_pose_initializer directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/yabloc_pose_initializer"
-    mode: "755"
-    state: directory
-
-- name: Download yabloc_pose_initializer/resources.tar.gz
-  become: true
-  ansible.builtin.get_url:
-    url: https://autoware-files.s3.us-west-2.amazonaws.com/models/yabloc/136_road-segmentation-adas-0001/resources.tar.gz
-    dest: "{{ data_dir }}/yabloc_pose_initializer/resources.tar.gz"
-    mode: "644"
-    checksum: sha256:1f660e15f95074bade32b1f80dbf618e9cee1f0b9f76d3f4671cb9be7f56eb3a
-
-- name: Extract yabloc_pose_initializer/resources.tar.gz
-  ansible.builtin.unarchive:
-    src: "{{ data_dir }}/yabloc_pose_initializer/resources.tar.gz"
-    dest: "{{ data_dir }}/yabloc_pose_initializer/"
+# v0.1 is the complete upstream PINTO export, the same file set the old archive delivered. Pruning it to the
+# files the node can actually use (tag v1.0) is a separate follow-up.
+- name: Download yabloc_pose_initializer model bundle ({{ revision }})
+  vars:
+    revision: v0.1
+  ansible.builtin.command:
+    cmd: >-
+      hf download AutowareFoundation/yabloc_pose_initializer
+      --revision {{ revision }}
+      --local-dir "{{ data_dir }}/yabloc_pose_initializer"
+  environment:
+    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
+    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
+  changed_when: false
 
 # bevfusion
 - name: Download bevfusion model bundle ({{ revision }})
@@ -47,24 +43,18 @@
   changed_when: false
 
 # bevdet
-- name: Create tensorrt_bevdet directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/tensorrt_bevdet"
-    mode: "755"
-    state: directory
-
-- name: Download tensorrt_bevdet/tensorrt_bevdet.tar.gz
-  become: true
-  ansible.builtin.get_url:
-    url: https://autoware-files.s3.us-west-2.amazonaws.com/models/tensorrt_bevdet.tar.gz
-    dest: "{{ data_dir }}/tensorrt_bevdet/tensorrt_bevdet.tar.gz"
-    mode: "644"
-    checksum: sha256:c7d16ad395e949e7a654ab511fb3294135553f92c50f2595e63a1b3e0d142c6a
-
-- name: Extract tensorrt_bevdet/tensorrt_bevdet.tar.gz
-  ansible.builtin.unarchive:
-    src: "{{ data_dir }}/tensorrt_bevdet/tensorrt_bevdet.tar.gz"
-    dest: "{{ data_dir }}/tensorrt_bevdet/"
+- name: Download tensorrt_bevdet model bundle ({{ revision }})
+  vars:
+    revision: v1.0
+  ansible.builtin.command:
+    cmd: >-
+      hf download AutowareFoundation/tensorrt_bevdet
+      --revision {{ revision }}
+      --local-dir "{{ data_dir }}/tensorrt_bevdet"
+  environment:
+    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
+    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
+  changed_when: false
 
 # image_projection_based_fusion
 - name: Download image_projection_based_fusion model bundle ({{ revision }})
@@ -81,35 +71,18 @@
   changed_when: false
 
 # lidar_apollo_instance_segmentation
-- name: Create lidar_apollo_instance_segmentation directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/lidar_apollo_instance_segmentation"
-    mode: "755"
-    state: directory
-
-- name: Download lidar_apollo_instance_segmentation/vlp-16.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/lidar_apollo_instance_segmentation/vlp-16.onnx
-    dest: "{{ data_dir }}/lidar_apollo_instance_segmentation/vlp-16.onnx"
-    mode: "644"
-    checksum: sha256:eec521ebad7553d0ea2c90472a293aecb7499ab592632f0e100481c8196eb421
-
-- name: Download lidar_apollo_instance_segmentation/hdl-64.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/lidar_apollo_instance_segmentation/hdl-64.onnx
-    dest: "{{ data_dir }}/lidar_apollo_instance_segmentation/hdl-64.onnx"
-    mode: "644"
-    checksum: sha256:86348d8c4bced750f54288b01cc471c0d4f1ec9c693466169ef19413731e6ecc
-
-- name: Download lidar_apollo_instance_segmentation/vls-128.onnx
-  become: true
-  ansible.builtin.get_url:
-    url: https://awf.ml.dev.web.auto/perception/models/lidar_apollo_instance_segmentation/vls-128.onnx
-    dest: "{{ data_dir }}/lidar_apollo_instance_segmentation/vls-128.onnx"
-    mode: "644"
-    checksum: sha256:95ef950bb694bd6de91b7e47f5d191d557e92a7f5e2a6bdf655a8b5eed4075cc
+- name: Download lidar_apollo_instance_segmentation model bundle ({{ revision }})
+  vars:
+    revision: v1.0
+  ansible.builtin.command:
+    cmd: >-
+      hf download AutowareFoundation/lidar_apollo_instance_segmentation
+      --revision {{ revision }}
+      --local-dir "{{ data_dir }}/lidar_apollo_instance_segmentation"
+  environment:
+    PATH: "{{ ansible_facts.env.HOME }}/.local/bin:{{ ansible_facts.env.PATH }}"
+    HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
+  changed_when: false
 
 # lidar_centerpoint
 - name: Download lidar_centerpoint model bundle ({{ revision }})


### PR DESCRIPTION
## Description

Batch D of the artifact hosting migration (#7223), the archive-based models. Two `get_url` + `unarchive` pairs and three per-file `get_url` tasks become one pinned `hf download` task each, following batches A (#7224), B (#7229) and C (#7244).

| Model | Revision | Replaces |
|---|---|---|
| [`yabloc_pose_initializer`](https://huggingface.co/AutowareFoundation/yabloc_pose_initializer) | `v0.1` | S3 `yabloc/136_road-segmentation-adas-0001/resources.tar.gz` |
| [`tensorrt_bevdet`](https://huggingface.co/AutowareFoundation/tensorrt_bevdet) | `v1.0` | S3 `tensorrt_bevdet.tar.gz` |
| [`lidar_apollo_instance_segmentation`](https://huggingface.co/AutowareFoundation/lidar_apollo_instance_segmentation) | `v1.0` | `perception/models/lidar_apollo_instance_segmentation/*.onnx` |

This PR only changes where the files come from, not which files land on disk. Every installed file is byte-identical to what the old hosting delivered, and destination paths are unchanged, so launch files need no update.

The two archives are the reason this batch is separate. The old tasks downloaded a `.tar.gz` and extracted it in place, which left the archive sitting next to its own extracted contents forever. Hugging Face stores files directly, so the extracted tree is what gets delivered and the container disappears. That is the entire on-disk difference for `yabloc_pose_initializer`: all 104 files of the PINTO model zoo export are still installed, only the 14 MB `resources.tar.gz` is gone. `tensorrt_bevdet.tar.gz` held exactly one file, `bevdet_one_lt_d.onnx`, which is still delivered; the node's configs live in the package and are unaffected. Nothing is dropped for `lidar_apollo_instance_segmentation`.

A fresh install of these three directories drops from 679.7 MB to 382.4 MB: `yabloc_pose_initializer` 56.0 MB -> 41.9 MB, `tensorrt_bevdet` 588.0 MB -> 304.8 MB, `lidar_apollo_instance_segmentation` unchanged at 35.7 MB.

The `yabloc_pose_initializer` repo has a second revision, `v1.0`, which keeps only `saved_model/model_float32.pb` and `saved_model/model_float32.onnx`. Switching the pin to it would save another 40 MB per install, but it does drop files, so it is deliberately left out of this PR and proposed separately with the package's code owners as reviewers. `v0.1` here keeps this change reviewable as a pure hosting move.

Known trade-offs, shared with the earlier batches:

- The migrated tasks drop `become: true`, so files are owned by the invoking user instead of root.
- Existing installs keep `resources.tar.gz` and `tensorrt_bevdet.tar.gz` as dead weight. Nothing re-downloads, `hf` recognizes the existing files by content hash, but the two archives have to be deleted by hand to reclaim the 297 MB.

## How to validate manually

### 1. Check out the branch

```bash
cd ~/projects/autoware
gh pr checkout 7248
```

### 2. Install the artifacts

```bash
ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
ansible-playbook autoware.dev_env.install_dev_env --tags artifacts \
  -e "data_dir=$HOME/autoware_data/ml_models" --ask-become-pass
```

`--ask-become-pass` is still needed because the not-yet-migrated models use `get_url` with `become`.

Expect the three tasks named `Download <model> model bundle (vX.Y)` to report `ok`, and the recap to show `failed=0`.

### 3. Verify the delivered files match what the removed pins delivered

The three apollo hashes and the bevdet archive member:

```bash
cd "$HOME/autoware_data/ml_models" && sha256sum -c <<'EOF'
47f156cb63ca97fa1d47b5d46eba648d4bbe71c95a08af14d3d0fdf53d800d77  tensorrt_bevdet/bevdet_one_lt_d.onnx
eec521ebad7553d0ea2c90472a293aecb7499ab592632f0e100481c8196eb421  lidar_apollo_instance_segmentation/vlp-16.onnx
86348d8c4bced750f54288b01cc471c0d4f1ec9c693466169ef19413731e6ecc  lidar_apollo_instance_segmentation/hdl-64.onnx
95ef950bb694bd6de91b7e47f5d191d557e92a7f5e2a6bdf655a8b5eed4075cc  lidar_apollo_instance_segmentation/vls-128.onnx
EOF
```

All four must print `OK`. The first hash is the archive member, reproducible from the removed archive pin with `tar -xzf tensorrt_bevdet.tar.gz -O bevdet_one_lt_d.onnx | sha256sum`.

For yabloc, compare the whole tree against a fresh extraction of the archive this PR stops downloading:

```bash
tmp=$(mktemp -d) && cd "$tmp"
curl -sO https://autoware-files.s3.us-west-2.amazonaws.com/models/yabloc/136_road-segmentation-adas-0001/resources.tar.gz
echo "1f660e15f95074bade32b1f80dbf618e9cee1f0b9f76d3f4671cb9be7f56eb3a  resources.tar.gz" | sha256sum -c
mkdir orig && tar -xzf resources.tar.gz -C orig
diff -r orig/saved_model "$HOME/autoware_data/ml_models/yabloc_pose_initializer/saved_model"
```

The only expected output is `Only in orig/saved_model: assets`, an empty directory that git cannot represent. All 104 files match byte for byte.

### 4. Confirm re-running is cheap and non-destructive

```bash
ansible-playbook autoware.dev_env.install_dev_env --tags artifacts \
  -e "data_dir=$HOME/autoware_data/ml_models" --ask-become-pass
```

The three tasks should finish in a few seconds. They always report `ok` (`changed_when: false`), so judge by elapsed time, not by the recap.

## CI

`install-artifacts` (label `run:health-check`) exercises all of the above on a clean runner and reports the total artifacts size. It should drop from 3.90 GB to about 3.60 GB, since the two archives are no longer downloaded alongside their extracted contents.

## Follow-ups

- Pin `yabloc_pose_initializer` to `v1.0`, which keeps the frozen graph the node loads plus an ONNX export of the same network and drops the TFLite, TF.js, OpenVINO and TF-TRT variants that nothing in Autoware reads. Saves about 40 MB per install. Separate PR, with the package code owners as reviewers.
- `yabloc_pose_initializer/README.md` in autoware_universe still documents the manual install as a `wget` plus `tar xzf` of the S3 archive. That needs a companion PR there; it cannot be fixed from this repository.

---

**AI usage:** written with Claude Code in an interactive session; I set the batch scope and the task pattern to follow.
**Self-review:** done. Every delivered file matches what the removed pins delivered, at unchanged paths, so this is good to go.
**Verification:** every delivered file was checked against the content the removed pins deliver. For the two archives the full chain was followed: archive hash from the removed pin, fresh extraction, Hugging Face content hash. For yabloc that is all 104 files, compared byte for byte against a fresh extraction of the original archive and against the Hugging Face LFS hashes at `v0.1`; for bevdet and apollo, the four sha256 values above. Ran a clean-room `hf download` into an empty directory (correct paths and hashes, 18.8 s for the yabloc bundle) and a download over an existing install (no model file was rewritten, mtimes preserved, a few seconds per bundle).

