### PR TITLE
chore: drop the orphaned tensorrt_rtmdet artifact and the trt_batched_nms repos entry

### DIFF
--- a/ansible/roles/artifacts/README.md
+++ b/ansible/roles/artifacts/README.md
@@ -2,7 +2,7 @@
 
 The Autoware perception stack uses models for inference. These models are downloaded by running `ansible-playbook autoware.dev_env.install_dev_env --tags artifacts`.
 
-The models are hosted on [Hugging Face](https://huggingface.co/AutowareFoundation) under the `AutowareFoundation` organization. Models that have not been migrated yet are still hosted by Web.Auto.
+The models are hosted on [Hugging Face](https://huggingface.co/AutowareFoundation) under the `AutowareFoundation` organization. `diffusion_planner` and `tensorrt_vad` have not been migrated yet and are still hosted by Web.Auto.
 
 Default `data_dir` location is `~/autoware_data/ml_models` (part of the asset-typed `~/autoware_data/` layout: `assets/`, `maps/`, `ml_models/`, `recordings/`, `scenarios/`).
 
@@ -68,7 +68,7 @@ This step should be repeated when a new playbook is added.
 ansible-playbook autoware.dev_env.install_dev_env --tags artifacts -e "data_dir=$HOME/autoware_data/ml_models" --ask-become-pass
 ```
 
-This will download and extract the artifacts to the specified directory. Files fetched with `get_url` are validated against checksums pinned in this role. Model bundles fetched from Hugging Face are pinned to a version tag instead; their integrity relies on the Hub and the transport, not on checksums pinned here.
+This will download the artifacts to the specified directory. Files fetched with `get_url` are validated against checksums pinned in this role. Model bundles fetched from Hugging Face are pinned to a version tag instead; their integrity relies on the Hub and the transport, not on checksums pinned here.
 
 ### Migrating from the legacy layout
 

--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -127,28 +127,6 @@
     HF_TOKEN: "{{ lookup('env', 'HF_TOKEN') }}"
   changed_when: false
 
-# tensorrt_rtmdet
-- name: Create tensorrt_rtmdet directory inside {{ data_dir }}
-  ansible.builtin.file:
-    path: "{{ data_dir }}/tensorrt_rtmdet"
-    mode: "755"
-    state: directory
-
-- name: Download tensorrt_rtmdet_onnx_models.tar.gz
-  become: true
-  ansible.builtin.get_url:
-    url: https://autoware-files.s3.us-west-2.amazonaws.com/models/tensorrt_rtmdet_onnx_models.tar.gz
-    dest: "{{ data_dir }}/tensorrt_rtmdet/tensorrt_rtmdet_onnx_models.tar.gz"
-    mode: "644"
-    checksum: sha256:eaf6fe9caf1b4a0211dc3b0f4068b1fd6c1d35fe1582cc2aed95b8ed9468c598
-
-- name: Extract tensorrt_rtmdet_onnx_models.tar.gz
-  ansible.builtin.unarchive:
-    src: "{{ data_dir }}/tensorrt_rtmdet/tensorrt_rtmdet_onnx_models.tar.gz"
-    dest: "{{ data_dir }}/tensorrt_rtmdet/"
-    extra_opts:
-      - --strip-components=1 # Removes the top-level folder during extraction
-
 # traffic_light_classifier
 - name: Download traffic_light_classifier model bundle ({{ revision }})
   vars:

--- a/repositories/autoware.repos
+++ b/repositories/autoware.repos
@@ -97,10 +97,6 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/bevdet_vendor.git
     version: 0.1.0
-  universe/external/trt_batched_nms:
-    type: git
-    url: https://github.com/autowarefoundation/trt_batched_nms.git
-    version: 0.1.0
   universe/external/cuda_blackboard:
     type: git
     url: https://github.com/autowarefoundation/cuda_blackboard.git


### PR DESCRIPTION
## Description

- `autoware_tensorrt_rtmdet` was never merged into `autoware_universe`. autowarefoundation/autoware_universe#8165 is closed and autowarefoundation/autoware_universe#7235 is closed as not planned, so the model artifact and its TensorRT plugin dependency have no consumer. Tracked in #7252.

Costs removed:

- Every fresh `--tags artifacts` install downloads `tensorrt_rtmdet_onnx_models.tar.gz` (462 MB) and extracts it, leaving both the tarball and its contents on disk (about 957 MB total, because the `unarchive` task never deletes the source tarball). The pinned checksum means it is fetched once per machine, not once per run.
- Every `vcs import` clones `autowarefoundation/trt_batched_nms`, which has no consumer in the workspace today. No `package.xml` or `CMakeLists.txt` under `src/` references it. The only package that ever declared it was the unmerged `autoware_tensorrt_rtmdet`, which resolved `libtrt_batched_nms_plugin.so` through `$(find-pkg-prefix trt_batched_nms)` for TensorRT to `dlopen`.

This resolves the last outstanding decision item in #7223, as "dropped, no consumer".

Changes:

- Remove the three `tensorrt_rtmdet` tasks from `ansible/roles/artifacts/tasks/main.yaml`.
- Remove `universe/external/trt_batched_nms` from `repositories/autoware.repos`.
- `ansible/roles/artifacts/README.md`: rtmdet was the only `unarchive` task in the role, so it no longer extracts anything. Also name the two models still on Web.Auto, since that is now just `diffusion_planner` and `tensorrt_vad`.

Note this does **not** claim the role is fully migrated to Hugging Face: 15 `get_url` tasks remain for `diffusion_planner` and `tensorrt_vad`, which move in a separate batch.

Not in scope, tracked in #7252: `autowarefoundation/openadkit` (two Dockerfiles) and `autowarefoundation/autoware-deb-packages` (`sources.repos`, pinned to a different SHA) each carry their own reference. The S3 object itself stays: several out-of-org projects `wget` it directly in their installers, so deleting it belongs to the hosting decommission in #7223 as a separately announced decision.

Companion docs PR: autowarefoundation/autoware-documentation#822, which should merge first.

## How was this PR tested?

- Both edited YAML files parse under PyYAML; `repositories/autoware.repos` goes from 32 to 31 entries.
- `ansible-lint ansible/roles/artifacts/`: 0 failures, 0 warnings, profile `production`.
- `pre-commit run --files` on all three: markdownlint, prettier, yamllint pass.
- `git grep -in "rtmdet\|trt_batched_nms"` returns nothing on the branch.
- The artifacts role now contains 0 `unarchive` tasks and 15 `get_url` tasks, which is what the two README edits assert.

## Effects on system behavior

No functional effect. Nothing in `autoware_universe` or `autoware_core` builds against `trt_batched_nms` or reads from `~/autoware_data/ml_models/tensorrt_rtmdet`.

`vcs import` has no prune, so existing workspaces keep `src/universe/external/trt_batched_nms` and colcon keeps building it until it is removed by hand. To reclaim the space:

```bash
rm -rf src/universe/external/trt_batched_nms ~/autoware_data/ml_models/tensorrt_rtmdet
```
